### PR TITLE
Feature/remove css nesting

### DIFF
--- a/docs/postcss.config.cjs
+++ b/docs/postcss.config.cjs
@@ -1,0 +1,3 @@
+module.exports = {
+  plugins: [require("postcss-nesting")],
+};

--- a/docs/src/components/BrandedCalendar.astro
+++ b/docs/src/components/BrandedCalendar.astro
@@ -49,7 +49,6 @@ const { class: className, value } = Astro.props;
       0 0 30px rgba(0, 0, 0, 0.01);
     inline-size: fit-content;
     margin-inline: auto;
-    block-size: fit-content;
 
     .grid {
       display: flex;

--- a/docs/src/components/Example.astro
+++ b/docs/src/components/Example.astro
@@ -1,6 +1,8 @@
 ---
 import { Code } from "astro:components";
 import * as prettier from "prettier";
+import postcss from "postcss";
+import nesting from "postcss-nesting";
 
 interface Props {
   lineLength?: number;
@@ -28,23 +30,30 @@ function cyrb53(str: string, seed = 0) {
 }
 
 const { css, lineLength = 80, class: className, ...rest } = Astro.props;
-
 const html = await Astro.slots.render("default");
-const source = `
-  ${css ? `<style>${css}</style>` : ""}
-  ${html}
-`;
 
-const id = `id-${cyrb53(source)}`;
+// ID used for scoping
+const id = `id-${cyrb53(css + html)}`;
+
+// compile away CSS nesting
+let compiledCss = css;
+if (css) {
+  const scoped = `#${id} { ${css} }`;
+  const result = await postcss([nesting]).process(scoped, { from: undefined });
+  compiledCss = result.css;
+}
+
+// the example to be rendered
 const output = `
-  ${css ? `<style>#${id}{ ${css} }</style>` : ""}
+  ${compiledCss ? `<style>${compiledCss}</style>` : ""}
   <div id="${id}">${html}</div>
 `;
 
-const formatted = await prettier.format(source, {
-  parser: "html",
-  printWidth: lineLength,
-});
+// the code shown to the user
+const formatted = await prettier.format(
+  `${css ? `<style>${css}</style>` : ""}${html}`,
+  { parser: "html", printWidth: lineLength }
+);
 
 // TODO: remove when this bug is resolved
 // https://github.com/withastro/compiler/issues/984

--- a/docs/src/components/Heading.astro
+++ b/docs/src/components/Heading.astro
@@ -30,12 +30,12 @@ const id = Astro.props.id ?? children.toLowerCase().replace(/\s/g, "-");
   }
 
   .hash {
-    display: none;
+    visibility: hidden;
     opacity: 0.5;
-    padding-inline: var(--space-3xs);
+    padding-inline-start: var(--space-3xs);
   }
 
   a:is(:hover, :focus-visible) .hash {
-    display: unset;
+    visibility: visible;
   }
 </style>

--- a/docs/src/components/Note.astro
+++ b/docs/src/components/Note.astro
@@ -17,12 +17,12 @@
     padding-block: var(--space-xs);
     margin-block-end: var(--space-s);
 
-    a {
+    :global(a) {
       --a-color: #90500a;
     }
+  }
 
-    p {
-      margin: 0;
-    }
+  p {
+    margin: 0;
   }
 </style>

--- a/docs/src/components/PageNav.astro
+++ b/docs/src/components/PageNav.astro
@@ -36,18 +36,18 @@ import LogoGithub from "./LogoGithub.astro";
   nav {
     --icon-size: var(--space-s);
     --icon-color: var(--color-body);
-
-    svg {
-      width: var(--icon-size);
-      height: var(--icon-size);
-      fill: var(--icon-color);
-
-      /* fix alignment */
-      margin-block-start: 1px;
-    }
   }
 
-  a {
+  nav :global(svg) {
+    width: var(--icon-size);
+    height: var(--icon-size);
+    fill: var(--icon-color);
+
+    /* fix alignment */
+    margin-block-start: 1px;
+  }
+
+  nav :global(a) {
     display: flex;
     gap: var(--space-3xs);
     align-items: center;

--- a/docs/src/components/PageTitle.astro
+++ b/docs/src/components/PageTitle.astro
@@ -25,10 +25,10 @@ interface Props {
     font-size: var(--step-4);
     text-decoration: none;
     border-block-end: var(--space-3xs) solid var(--color-accent);
-  }
 
-  .title:focus-visible {
-    outline-offset: 3px;
-    outline-width: 3px;
+    &:focus-visible {
+      outline-offset: 3px;
+      outline-width: 3px;
+    }
   }
 </style>

--- a/docs/src/components/Table.astro
+++ b/docs/src/components/Table.astro
@@ -14,28 +14,27 @@
     border-collapse: collapse;
     min-inline-size: var(--container-size);
 
-    th,
-    td {
+    :global(th, td) {
       padding-block: var(--space-xs);
       padding-inline: var(--space-2xs);
     }
 
-    td {
+    :global(td) {
       border-block-end: 1px solid var(--color-border);
       vertical-align: top;
     }
 
-    th {
+    :global(th) {
       text-align: start;
       font-weight: 500;
       border-block-end: 1px solid var(--color-heading);
     }
 
-    :is(td, th):first-child {
+    :global(:is(td, th):first-child) {
       padding-inline-start: 0;
     }
 
-    :is(td, th):last-child {
+    :global(:is(td, th):last-child) {
       padding-inline-end: 0;
     }
   }

--- a/docs/src/pages/components/calendar-date.astro
+++ b/docs/src/pages/components/calendar-date.astro
@@ -245,7 +245,6 @@ import Link from "../../components/Link.astro";
 
 <style is:global>
   calendar-date {
-    inline-size: fit-content;
     margin-inline: auto;
   }
 </style>

--- a/docs/src/pages/components/calendar-range.astro
+++ b/docs/src/pages/components/calendar-range.astro
@@ -259,7 +259,6 @@ import Link from "../../components/Link.astro";
 
 <style is:global>
   calendar-range {
-    inline-size: fit-content;
     margin-inline: auto;
   }
 </style>

--- a/docs/src/pages/components/calendar-range.astro
+++ b/docs/src/pages/components/calendar-range.astro
@@ -26,7 +26,6 @@ import Link from "../../components/Link.astro";
       min="2024-01-01"
       max="2024-12-31"
       locale="en-GB"
-      months="2"
     >
       <calendar-month></calendar-month>
     </calendar-range>

--- a/docs/src/pages/guides/frameworks.astro
+++ b/docs/src/pages/guides/frameworks.astro
@@ -38,14 +38,12 @@ import { Code } from "astro:components";
   </p>
 
   <Note>
-    <p>
-      <strong>Note:</strong> the next major version of React will offer
-      <a
-        href="https://github.com/facebook/react/issues/11347#issuecomment-1899140345"
-        >full support for web components</a
-      >, making these wrappers unnecessary. Though no release date has been set
-      yet.
-    </p>
+    <strong>Note:</strong> the next major version of React will offer
+    <a
+      href="https://github.com/facebook/react/issues/11347#issuecomment-1899140345"
+      >full support for web components</a
+    >, making these wrappers unnecessary. Though no release date has been set
+    yet.
   </Note>
 
   <p>
@@ -411,13 +409,11 @@ declare global {
   />
 
   <Note>
-    <p>
-      This uses TypeScript's declaration merging feature. You can read more
-      about it in the <a
-        href="https://www.typescriptlang.org/docs/handbook/declaration-merging.html"
-        >TypeScript Handbook</a
-      >.
-    </p>
+    This uses TypeScript's declaration merging feature. You can read more about
+    it in the <a
+      href="https://www.typescriptlang.org/docs/handbook/declaration-merging.html"
+      >TypeScript Handbook</a
+    >.
   </Note>
 
   <p>
@@ -504,13 +500,11 @@ declare module "svelte/elements" {
   />
 
   <Note>
-    <p>
-      This uses TypeScript's declaration merging feature. You can read more
-      about it in the <a
-        href="https://www.typescriptlang.org/docs/handbook/declaration-merging.html"
-        >TypeScript Handbook</a
-      >.
-    </p>
+    This uses TypeScript's declaration merging feature. You can read more about
+    it in the <a
+      href="https://www.typescriptlang.org/docs/handbook/declaration-merging.html"
+      >TypeScript Handbook</a
+    >.
   </Note>
 
   <p>

--- a/docs/src/pages/guides/theming.astro
+++ b/docs/src/pages/guides/theming.astro
@@ -71,10 +71,6 @@ const colorTextOnAccent = "#ffffff";
         flex-wrap: wrap;
         justify-content: center;
       }
-
-      calendar-range {
-        inline-size: fit-content;
-      }
     `}
   >
     <calendar-range
@@ -125,8 +121,6 @@ const colorTextOnAccent = "#ffffff";
       }
 
       calendar-range {
-        inline-size: fit-content;
-
         svg {
           height: 16px;
           width: 16px;
@@ -210,8 +204,6 @@ const colorTextOnAccent = "#ffffff";
       }
 
       calendar-range {
-        inline-size: fit-content;
-
         svg {
           height: 16px;
           width: 16px;
@@ -294,8 +286,6 @@ const colorTextOnAccent = "#ffffff";
     }
 
     calendar-range {
-      inline-size: fit-content;
-
       svg {
         height: 16px;
         width: 16px;
@@ -379,8 +369,6 @@ const colorTextOnAccent = "#ffffff";
       }
 
       calendar-range {
-        inline-size: fit-content;
-
         svg {
           height: 16px;
           width: 16px;
@@ -490,8 +478,6 @@ const colorTextOnAccent = "#ffffff";
       }
 
       calendar-range {
-        inline-size: fit-content;
-
         svg {
           height: 16px;
           width: 16px;

--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -200,6 +200,5 @@ const tagline = "Small, feature-rich calendar components";
   calendar-date,
   calendar-range {
     margin: 0 auto;
-    inline-size: fit-content;
   }
 </style>

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "@web/test-runner-playwright": "^0.11.0",
         "@web/test-runner-visual-regression": "^0.9.0",
         "astro": "^4.5.10",
+        "postcss-nesting": "^12.1.1",
         "prettier": "^3.2.5",
         "typescript": "^5.3.3",
         "vite": "^5.1.4",
@@ -748,6 +749,50 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@csstools/selector-resolve-nested": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/selector-resolve-nested/-/selector-resolve-nested-1.1.0.tgz",
+      "integrity": "sha512-uWvSaeRcHyeNenKg8tp17EVDRkpflmdyvbE0DHo6D/GdBb6PDnCYYU6gRpXhtICMGMcahQmj2zGxwFM/WC8hCg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "postcss-selector-parser": "^6.0.13"
+      }
+    },
+    "node_modules/@csstools/selector-specificity": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-3.0.3.tgz",
+      "integrity": "sha512-KEPNw4+WW5AVEIyzC80rTbWEUatTW2lXpN8+8ILC8PiPeWPjwUzrPZDIOZ2wwqDmeqOYTdSGyL3+vE5GC3FB3Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "postcss-selector-parser": "^6.0.13"
       }
     },
     "node_modules/@emmetio/abbreviation": {
@@ -8245,6 +8290,46 @@
         "ts-node": {
           "optional": true
         }
+      }
+    },
+    "node_modules/postcss-nesting": {
+      "version": "12.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-nesting/-/postcss-nesting-12.1.1.tgz",
+      "integrity": "sha512-qc74KvIAQNa5ujZKG1UV286dhaDW6basbUy2i9AzNU/T8C9hpvGu9NZzm1SfePe2yP7sPYgpA8d4sPVopn2Hhw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "dependencies": {
+        "@csstools/selector-resolve-nested": "^1.1.0",
+        "@csstools/selector-specificity": "^3.0.3",
+        "postcss-selector-parser": "^6.0.13"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "node_modules/postcss-selector-parser": {
+      "version": "6.0.16",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.16.tgz",
+      "integrity": "sha512-A0RVJrX+IUkVZbW3ClroRWurercFhieevHB38sr2+l9eUClMqome3LmEmnhlNy+5Mr2EYN6B2Kaw9wYdd+VHiw==",
+      "dev": true,
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/prebuild-install": {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "@web/test-runner-playwright": "^0.11.0",
     "@web/test-runner-visual-regression": "^0.9.0",
     "astro": "^4.5.10",
+    "postcss-nesting": "^12.1.1",
     "prettier": "^3.2.5",
     "typescript": "^5.3.3",
     "vite": "^5.1.4",


### PR DESCRIPTION
I had a few complaints that the examples were broken in the docs. Seems native CSS nesting is a little too bleeding edge for now. So let's compile it away using `postcss`.

Fixes #6 