### PR TITLE
remove padding from buttons, fix ios layout

### DIFF
--- a/src/utils/styles.ts
+++ b/src/utils/styles.ts
@@ -6,6 +6,11 @@ export const reset = css`
   *::after {
     box-sizing: border-box;
   }
+
+  button {
+    padding: 0;
+    touch-action: manipulation;
+  }
 `;
 
 export const vh = css`


### PR DESCRIPTION
* removes padding from buttons to fix ios layout
* adds `touch-action: manipulation` to prevent zoom on successive taps of button

fixes #7