### PR TITLE
fix issue with empty range value, add tests

### DIFF
--- a/src/calendar-month/calendar-month.test.tsx
+++ b/src/calendar-month/calendar-month.test.tsx
@@ -8,6 +8,7 @@ import {
   getMonthHeading,
   getMonth,
   getDayButton,
+  getSelectedDays,
 } from "../utils/test.js";
 import {
   CalendarMonthContext,
@@ -76,6 +77,64 @@ describe("CalendarMonth", () => {
     expect(calendar).to.be.instanceOf(CalendarMonth);
   });
 
+  describe("value types", () => {
+    describe("range", () => {
+      it("handles an empty value", async () => {
+        const month = await mount(
+          <Fixture
+            highlightedRange={[]}
+            focusedDate={PlainDate.from("2024-01-01")}
+          />
+        );
+
+        const selected = getSelectedDays(month);
+        expect(selected.length).to.eq(0);
+      });
+
+      it("marks a range as selected", async () => {
+        const month = await mount(
+          <Fixture
+            focusedDate={PlainDate.from("2020-01-01")}
+            highlightedRange={[
+              PlainDate.from("2020-01-01"),
+              PlainDate.from("2020-01-03"),
+            ]}
+          />
+        );
+
+        const selected = getSelectedDays(month);
+        expect(selected.length).to.eq(3);
+        expect(selected[0]).to.have.attribute("aria-label", "1 January");
+        expect(selected[1]).to.have.attribute("aria-label", "2 January");
+        expect(selected[2]).to.have.attribute("aria-label", "3 January");
+      });
+    });
+
+    describe("single date", () => {
+      it("handles an empty value", async () => {
+        const month = await mount(
+          <Fixture focusedDate={PlainDate.from("2024-01-01")} />
+        );
+
+        const selected = getSelectedDays(month);
+        expect(selected.length).to.eq(0);
+      });
+
+      it("marks a single date as selected", async () => {
+        const month = await mount(
+          <Fixture
+            focusedDate={PlainDate.from("2020-01-01")}
+            value={PlainDate.from("2020-01-01")}
+          />
+        );
+
+        const selected = getSelectedDays(month);
+        expect(selected.length).to.eq(1);
+        expect(selected[0]).to.have.attribute("aria-label", "1 January");
+      });
+    });
+  });
+
   describe("a11y/ARIA requirements", () => {
     describe("grid", () => {
       it("is labelled", async () => {
@@ -96,9 +155,7 @@ describe("CalendarMonth", () => {
         const grid = getGrid(month);
 
         // should be single selected element
-        const selected = grid.querySelectorAll<HTMLButtonElement>(
-          `[aria-pressed="true"]`
-        );
+        const selected = getSelectedDays(month);
 
         expect(selected.length).to.eq(1);
         expect(selected[0]).to.have.trimmed.text("2");
@@ -124,8 +181,6 @@ describe("CalendarMonth", () => {
         expect(focusable[0]).to.have.trimmed.text("1");
         expect(focusable[0]).to.have.attribute("aria-label", "1 January");
       });
-
-      it("correctly abbreviates the shortened day names");
     });
   });
 

--- a/src/calendar-month/useCalendarMonth.ts
+++ b/src/calendar-month/useCalendarMonth.ts
@@ -121,7 +121,7 @@ export function useCalendarMonth({ props, context }: UseCalendarMonthOptions) {
       const [start, end] = context.highlightedRange;
       const isRangeStart = start?.equals(date);
       const isRangeEnd = end?.equals(date);
-      isSelected = inRange(date, start, end);
+      isSelected = start && end && inRange(date, start, end);
 
       // prettier-ignore
       parts = `${

--- a/src/calendar-range/calendar-range.test.tsx
+++ b/src/calendar-range/calendar-range.test.tsx
@@ -10,6 +10,7 @@ import {
   getMonthHeading,
   getNextPageButton,
   getPrevPageButton,
+  getSelectedDays,
   mount,
 } from "../utils/test.js";
 
@@ -24,6 +25,7 @@ type TestProps = {
   value: string;
   min: string;
   max: string;
+  focusedDate?: string;
   months?: number;
   children?: VNodeAny;
 };

--- a/src/utils/test.ts
+++ b/src/utils/test.ts
@@ -124,6 +124,14 @@ export function getNextPageButton(calendar: CalendarInstance) {
   )!;
 }
 
+export function getSelectedDays(month: MonthInstance) {
+  return [
+    ...month.shadowRoot!.querySelectorAll<HTMLButtonElement>(
+      `button[aria-pressed="true"]`
+    ),
+  ];
+}
+
 export function getDayButton(month: MonthInstance, dateLabel: string) {
   const grid = getGrid(month);
 


### PR DESCRIPTION
there was a flaw in the logic that resulted in this:

```html
<calendar-range value="">
  <calendar-month></calendar-month>
</calendar-range>
```

initially showing every date as selected. simple fix, and added some tests to catch future regressions