### PR TITLE
Add data-date attribute to calendar month

### DIFF
--- a/src/calendar-month/calendar-month.test.tsx
+++ b/src/calendar-month/calendar-month.test.tsx
@@ -144,6 +144,7 @@ describe("CalendarMonth", () => {
         const selected = getSelectedDays(month);
         expect(selected.length).to.eq(1);
         expect(selected[0]).to.have.attribute("aria-label", "1 January");
+        expect(selected[0]).to.have.attribute("data-date", "2020-01-01");
         expect(selected[0]!.part.contains("selected")).to.eq(true);
       });
     });
@@ -178,8 +179,11 @@ describe("CalendarMonth", () => {
         const selected = getSelectedDays(month);
         expect(selected.length).to.eq(3);
         expect(selected[0]).to.have.attribute("aria-label", "1 January");
+        expect(selected[0]).to.have.attribute("data-date", "2020-01-01");
         expect(selected[1]).to.have.attribute("aria-label", "2 January");
+        expect(selected[1]).to.have.attribute("data-date", "2020-01-02");
         expect(selected[2]).to.have.attribute("aria-label", "3 January");
+        expect(selected[2]).to.have.attribute("data-date", "2020-01-03");
       });
     });
   });

--- a/src/calendar-month/useCalendarMonth.ts
+++ b/src/calendar-month/useCalendarMonth.ts
@@ -154,6 +154,7 @@ export function useCalendarMonth({ props, context }: UseCalendarMonthOptions) {
       "aria-pressed": isInMonth && isSelected,
       "aria-current": isToday ? "date" : undefined,
       "aria-label": dayFormatter.format(asDate),
+      "data-date": date.toString(),
       onkeydown: onKeyDown,
       onclick() {
         if (!isDisallowed) {


### PR DESCRIPTION
I've got similar problems to the ones outlined in https://github.com/WickyNilliams/cally/issues/54, where I'd like to be able to have different styles for each date based on an external condition.

I figured given the [last comment](https://github.com/WickyNilliams/cally/issues/54#issuecomment-2175530730) on that thread indicates it might be tricky to get right, that it might take some time for a good solution to arrive for that. It might help in the meantime if there was a more reliable attribute on the calendar we could grab onto via the shadow root.

This PR adds a `data-date="YYYY-MM-DD"` attribute to each button in the calendar, such that you can script in your own styles as you please by committing some crimes against the shadow root, i.e.

```
// attach custom styles:
for (const cal of document.querySelectorAll('calendar-month')) {
  cal.shadowRoot.adoptedStyleSheets.push(customStyles);
}

// search the calendars for the specific date and add a custom class:
for (const cal of document.querySelectorAll('calendar-month')) {
  cal.shadowRoot.querySelector('[data-date="2024-01-01"]').className = 'yep';
}
```

I can _sort of_ do all of this with the aria label already, but it doesn't have the year in it and may be subject to localisation issues. At least with an ISO date, I have a slightly more reliable thing I can grab on to.

The above demonstration code is pretty hacky, but this change allows the hacks to live entirely in my app, not cally, which I can live with as it does at least let me do what I need without having to ask too many compromises of cally in the near term, while a longer term solution is conceived in #54.