### PR TITLE
allow custom day styles

### DIFF
--- a/docs/src/pages/components/calendar-date.astro
+++ b/docs/src/pages/components/calendar-date.astro
@@ -138,7 +138,7 @@ import Link from "../../components/Link.astro";
       <td><code>() =&gt; false</code></td>
     </tr>
     <tr>
-      <td><code>getPartsForDate</code></td>
+      <td><code>getDayParts</code></td>
       <td>-</td>
       <td>
         A function that takes a date and returns a string of CSS parts, allowing

--- a/docs/src/pages/components/calendar-date.astro
+++ b/docs/src/pages/components/calendar-date.astro
@@ -137,6 +137,16 @@ import Link from "../../components/Link.astro";
       <td><code>(date: Date) =&gt; boolean</code></td>
       <td><code>() =&gt; false</code></td>
     </tr>
+    <tr>
+      <td><code>getPartsForDate</code></td>
+      <td>-</td>
+      <td>
+        A function that takes a date and returns a string of CSS parts, allowing
+        custom styling for individual dates
+      </td>
+      <td><code>(date: Date) =&gt; string</code></td>
+      <td><code>() =&gt; ""</code></td>
+    </tr>
   </Table>
 
   <Heading level={2}>Events</Heading>

--- a/docs/src/pages/components/calendar-multi.astro
+++ b/docs/src/pages/components/calendar-multi.astro
@@ -138,7 +138,7 @@ import Link from "../../components/Link.astro";
       <td><code>() =&gt; false</code></td>
     </tr>
     <tr>
-      <td><code>getPartsForDate</code></td>
+      <td><code>getDayParts</code></td>
       <td>-</td>
       <td>
         A function that takes a date and returns a string of CSS parts, allowing

--- a/docs/src/pages/components/calendar-multi.astro
+++ b/docs/src/pages/components/calendar-multi.astro
@@ -137,6 +137,16 @@ import Link from "../../components/Link.astro";
       <td><code>(date: Date) =&gt; boolean</code></td>
       <td><code>() =&gt; false</code></td>
     </tr>
+    <tr>
+      <td><code>getPartsForDate</code></td>
+      <td>-</td>
+      <td>
+        A function that takes a date and returns a string of CSS parts, allowing
+        custom styling for individual dates
+      </td>
+      <td><code>(date: Date) =&gt; string</code></td>
+      <td><code>() =&gt; ""</code></td>
+    </tr>
   </Table>
 
   <Heading level={2}>Events</Heading>

--- a/docs/src/pages/components/calendar-range.astro
+++ b/docs/src/pages/components/calendar-range.astro
@@ -152,7 +152,7 @@ import Link from "../../components/Link.astro";
       <td><code>() =&gt; false</code></td>
     </tr>
     <tr>
-      <td><code>getPartsForDate</code></td>
+      <td><code>getDayParts</code></td>
       <td>-</td>
       <td>
         A function that takes a date and returns a string of CSS parts, allowing

--- a/docs/src/pages/components/calendar-range.astro
+++ b/docs/src/pages/components/calendar-range.astro
@@ -151,6 +151,16 @@ import Link from "../../components/Link.astro";
       <td><code>(date: Date) =&gt; boolean</code></td>
       <td><code>() =&gt; false</code></td>
     </tr>
+    <tr>
+      <td><code>getPartsForDate</code></td>
+      <td>-</td>
+      <td>
+        A function that takes a date and returns a string of CSS parts, allowing
+        custom styling for individual dates
+      </td>
+      <td><code>(date: Date) =&gt; string</code></td>
+      <td><code>() =&gt; ""</code></td>
+    </tr>
   </Table>
 
   <Heading level={2}>Events</Heading>

--- a/index.html
+++ b/index.html
@@ -36,6 +36,13 @@
         width: 100%;
         text-align: center;
       }
+
+      ::part(foo) {
+        background: red;
+      }
+      ::part(bar) {
+        background: blue;
+      }
     </style>
   </head>
   <body>
@@ -114,6 +121,14 @@
 
       if (window.range) {
         let start = null;
+
+        window.range.getPartsForDate = (date) => {
+          const d = date.getUTCDate();
+
+          if (d % 5 === 0) return "foo";
+          if (d % 9 === 0) return "bar";
+          return "";
+        };
 
         window.range.addEventListener("rangestart", (e) => {
           const { detail } = e;

--- a/index.html
+++ b/index.html
@@ -122,7 +122,7 @@
       if (window.range) {
         let start = null;
 
-        window.range.getPartsForDate = (date) => {
+        window.range.getDayParts = (date) => {
           const d = date.getUTCDate();
 
           if (d % 5 === 0) return "foo";

--- a/src/calendar-base/calendar-base.tsx
+++ b/src/calendar-base/calendar-base.tsx
@@ -1,6 +1,6 @@
 import { css } from "atomico";
 import {
-  CalendarMonthContext,
+  CalendarContext,
   type CalendarDateContext,
   type CalendarMultiContext,
   type CalendarRangeContext,
@@ -67,14 +67,14 @@ export function CalendarBase(
         </Button>
       </div>
 
-      <CalendarMonthContext
+      <CalendarContext
         value={props}
         onselectday={props.onSelect}
         onfocusday={props.onFocus}
         onhoverday={props.onHover}
       >
         <slot></slot>
-      </CalendarMonthContext>
+      </CalendarContext>
     </div>
   );
 }
@@ -99,6 +99,10 @@ export const props = {
   formatWeekday: {
     type: String,
     value: (): "narrow" | "short" => "narrow",
+  },
+  getPartsForDate: {
+    type: Function,
+    value: (date: Date): string => "",
   },
   firstDayOfWeek: {
     type: Number,

--- a/src/calendar-base/calendar-base.tsx
+++ b/src/calendar-base/calendar-base.tsx
@@ -100,7 +100,7 @@ export const props = {
     type: String,
     value: (): "narrow" | "short" => "narrow",
   },
-  getPartsForDate: {
+  getDayParts: {
     type: Function,
     value: (date: Date): string => "",
   },

--- a/src/calendar-date/calendar-date.test.tsx
+++ b/src/calendar-date/calendar-date.test.tsx
@@ -836,7 +836,7 @@ describe("CalendarDate", () => {
     const almostGone = new Set(["2020-01-13", "2020-01-14"]);
 
     const calendar = await mount(<Fixture value="2020-01-01" />);
-    calendar.getPartsForDate = function getPartsForDate(date: Date) {
+    calendar.getDayParts = function getDayParts(date: Date) {
       const d = PlainDate.from(date).toString();
 
       if (available.has(d)) return "available";

--- a/src/calendar-month/CalendarMonthContext.ts
+++ b/src/calendar-month/CalendarMonthContext.ts
@@ -7,7 +7,7 @@ interface CalendarContextBase {
   max?: PlainDate;
   firstDayOfWeek: DaysOfWeek;
   isDateDisallowed?: (date: Date) => boolean;
-  getPartsForDate?: (date: Date) => string;
+  getDayParts?: (date: Date) => string;
   page: { start: PlainYearMonth; end: PlainYearMonth };
   focusedDate: PlainDate;
   showOutsideDays?: boolean;

--- a/src/calendar-month/CalendarMonthContext.ts
+++ b/src/calendar-month/CalendarMonthContext.ts
@@ -2,11 +2,12 @@ import { createContext } from "atomico";
 import type { PlainDate, PlainYearMonth } from "../utils/temporal.js";
 import { today, type DaysOfWeek } from "../utils/date.js";
 
-interface CalendarMonthContextBase {
+interface CalendarContextBase {
   min?: PlainDate;
   max?: PlainDate;
   firstDayOfWeek: DaysOfWeek;
   isDateDisallowed?: (date: Date) => boolean;
+  getPartsForDate?: (date: Date) => string;
   page: { start: PlainYearMonth; end: PlainYearMonth };
   focusedDate: PlainDate;
   showOutsideDays?: boolean;
@@ -14,31 +15,33 @@ interface CalendarMonthContextBase {
   formatWeekday: "narrow" | "short";
 }
 
-export interface CalendarDateContext extends CalendarMonthContextBase {
+export interface CalendarDateContext extends CalendarContextBase {
   type: "date";
   value?: PlainDate;
 }
 
-export interface CalendarRangeContext extends CalendarMonthContextBase {
+export interface CalendarRangeContext extends CalendarContextBase {
   type: "range";
   value: [PlainDate, PlainDate] | [];
 }
 
-export interface CalendarMultiContext extends CalendarMonthContextBase {
+export interface CalendarMultiContext extends CalendarContextBase {
   type: "multi";
   value: PlainDate[];
 }
 
-export type CalendarMonthContextValue =
+export type CalendarContextValue =
   | CalendarDateContext
   | CalendarRangeContext
   | CalendarMultiContext;
 
 const t = today();
 
-export const CalendarMonthContext = createContext<CalendarMonthContextValue>({
+export const CalendarContext = createContext<CalendarContextValue>({
+  type: "date",
+  firstDayOfWeek: 1,
   focusedDate: t,
   page: { start: t.toPlainYearMonth(), end: t.toPlainYearMonth() },
-} as CalendarMonthContextValue);
+} as CalendarContextValue);
 
-customElements.define("calendar-month-ctx", CalendarMonthContext);
+customElements.define("calendar-ctx", CalendarContext);

--- a/src/calendar-month/calendar-month.test.tsx
+++ b/src/calendar-month/calendar-month.test.tsx
@@ -13,7 +13,7 @@ import {
   sendShiftPress,
 } from "../utils/test.js";
 import {
-  CalendarMonthContext,
+  CalendarContext,
   type CalendarDateContext,
   type CalendarMultiContext,
   type CalendarRangeContext,
@@ -23,7 +23,7 @@ import { fixture } from "atomico/test-dom";
 import { PlainDate } from "../utils/temporal.js";
 import { toDate, today } from "../utils/date.js";
 
-type MonthContextInstance = InstanceType<typeof CalendarMonthContext>;
+type MonthContextInstance = InstanceType<typeof CalendarContext>;
 
 interface TestPropsBase {
   onselectday?: (e: CustomEvent<PlainDate>) => void;
@@ -47,7 +47,7 @@ function Fixture({
   ...props
 }: Partial<DateTestProps | RangeTestProps | MultiTestProps>): VNodeAny {
   return (
-    <CalendarMonthContext
+    <CalendarContext
       onselectday={onselectday}
       onfocusday={onfocusday}
       dir={dir}
@@ -66,7 +66,7 @@ function Fixture({
       }}
     >
       <CalendarMonth />
-    </CalendarMonthContext>
+    </CalendarContext>
   );
 }
 

--- a/src/calendar-month/calendar-month.tsx
+++ b/src/calendar-month/calendar-month.tsx
@@ -1,7 +1,7 @@
 import { c, css, useContext, useRef, type Host } from "atomico";
 import { reset, vh } from "../utils/styles.js";
 import { useCalendarMonth } from "./useCalendarMonth.js";
-import { CalendarMonthContext } from "./CalendarMonthContext.js";
+import { CalendarContext } from "./CalendarMonthContext.js";
 import { toDate } from "../utils/date.js";
 
 export const CalendarMonth = c(
@@ -12,7 +12,7 @@ export const CalendarMonth = c(
     onFocusDay: CustomEvent<string>;
     onHoverDay: CustomEvent<string>;
   }> => {
-    const context = useContext(CalendarMonthContext);
+    const context = useContext(CalendarContext);
     const table = useRef<HTMLTableElement>();
     const calendar = useCalendarMonth({ props, context });
 

--- a/src/calendar-month/useCalendarMonth.ts
+++ b/src/calendar-month/useCalendarMonth.ts
@@ -9,7 +9,7 @@ import {
   today,
 } from "../utils/date.js";
 import type { PlainDate } from "../utils/temporal.js";
-import type { CalendarMonthContextValue } from "./CalendarMonthContext.js";
+import type { CalendarContextValue } from "./CalendarMonthContext.js";
 
 const inRange = (date: PlainDate, min?: PlainDate, max?: PlainDate) =>
   clamp(date, min, max) === date;
@@ -23,7 +23,7 @@ const dispatchOptions = { bubbles: true };
 
 type UseCalendarMonthOptions = {
   props: { offset: number };
-  context: CalendarMonthContextValue;
+  context: CalendarContextValue;
 };
 
 export function useCalendarMonth({ props, context }: UseCalendarMonthOptions) {
@@ -148,6 +148,8 @@ export function useCalendarMonth({ props, context }: UseCalendarMonthOptions) {
       isDisallowed ? "disallowed" : ""
     } ${
       isToday ? "today" : ""
+    } ${
+      context.getPartsForDate?.(asDate) ?? ""
     }`;
 
     return {

--- a/src/calendar-month/useCalendarMonth.ts
+++ b/src/calendar-month/useCalendarMonth.ts
@@ -149,7 +149,7 @@ export function useCalendarMonth({ props, context }: UseCalendarMonthOptions) {
     } ${
       isToday ? "today" : ""
     } ${
-      context.getPartsForDate?.(asDate) ?? ""
+      context.getDayParts?.(asDate) ?? ""
     }`;
 
     return {


### PR DESCRIPTION
* adds new prop `getDayParts: (date: Date) => string` 
* this can be used for adding a custom CSS part for any day that gets rendered
* css parts are selectable outside of shadow dom, enabling custom styles per day

doesn't quite solve #54, but does improve the situation

example:

```html
<style>
calendar-month::part(available) {
  background: green;
}
</style>

<calendar-date>
  <calendar-month></calendar-month>
</calendar-date>

<script>
const available = ["2024-09-22", "2024-09-23", "2024-09-24"]
calendar.getDayParts = date => available.includes(toISOString(date)) ? "available" : ""
</script>
```

**TODO**

- [x] docs
- [x] decide final naming 