### PR TITLE
test: edit two years heading check to be consistent

### DIFF
--- a/src/calendar-date/calendar-date.test.tsx
+++ b/src/calendar-date/calendar-date.test.tsx
@@ -465,14 +465,14 @@ describe("CalendarDate", () => {
 
         // move one year ahead
         await sendShiftPress("PageDown");
-        expect(getCalendarVisibleHeading(calendar)).to.have.text("2020–2021");
+        expect(getCalendarVisibleHeading(calendar)).to.include.text("2020").and.include.text("2021");
         expect(getMonthHeading(first)).to.have.text("December");
         expect(getMonthHeading(second)).to.have.text("January");
 
         // move one year back
         await sendShiftPress("PageUp");
         expect(getMonthHeading(first)).to.have.text("December");
-        expect(getCalendarVisibleHeading(calendar)).to.have.text("2019–2020");
+        expect(getCalendarVisibleHeading(calendar)).to.include.text("2019").and.include.text("2020");
         expect(getMonthHeading(second)).to.have.text("January");
       });
 
@@ -550,7 +550,7 @@ describe("CalendarDate", () => {
         await nextFrame();
         expect(getMonthHeading(first)).to.have.text("December");
         expect(getMonthHeading(second)).to.have.text("January");
-        expect(getCalendarVisibleHeading(calendar)).to.have.text("2020–2021");
+        expect(getCalendarVisibleHeading(calendar)).to.include.text("2020").and.include.text("2021");
       });
     });
   });


### PR DESCRIPTION
TL;DR: I assume the purpose of those tests is to verify that two years exist. Based on that thought, I fixed the tests failing in my environment.

I cloned the main branch of Cally and `npm test` but some tests failed.
It seems that there are some inconsistencies somewhere between browsers, OSes, and Playwright.

- I'm using macOS 15.2, Chrome 132.0.6834.160, Safari 18.2, Node.js 23.3.0, npm 10.9.0.
  - Personally, macOS is the most suspicious but no concrete reasoning/proof.
- Without modification, two tests failed in Webkit only:
```sh
❯❯❯ npm test

> cally@0.7.2 test
> wtr

(node:51045) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
(Use `node --trace-deprecation ...` to show where the warning was created)

src/calendar-date/calendar-date.test.tsx:

 ❌ CalendarDate > page by > single > updates page as user navigates dates (failed on Webkit)
      AssertionError: expected div[aria-hidden="true"] to have text '2020–2021', but the text was '2020 – 2021'
      + expected - actual
      
      -2020 – 2021
      +2020–2021
      
      at src/calendar-date/calendar-date.test.tsx:468:65

 ❌ CalendarDate > page by > single > handles focused date prop changing (failed on Webkit)
      AssertionError: expected div[aria-hidden="true"] to have text '2020–2021', but the text was '2020 – 2021'
      + expected - actual
      
      -2020 – 2021
      +2020–2021
      
      at src/calendar-date/calendar-date.test.tsx:553:65

Chromium: |██████████████████████████████| 5/5 test files | 100 passed, 0 fail
ed
Webkit:   |██████████████████████████████| 5/5 test files | 98 passed, 2 faile
d

Finished running tests in 2.3s with 2 failed tests.
```
- It turns out that `Intl` heavily depends on implementation for formatting. Sometimes the formatter uses em dash (—, U+2014) and other times it uses en dash (–, U+2013)
- Besides, It uses tilde (~, U+007E) for ko-KR locale, which is my current locale
- So I thought it makes sense to ignore those characters with Chai's `include` API