### PR TITLE
fix: duplicated calendar id in sample html

### DIFF
--- a/index.html
+++ b/index.html
@@ -89,7 +89,7 @@
 
     <h2>multi</h2>
     <calendar-multi
-      id="date"
+      id="multi"
       months="2"
       show-outside-days
       value="2024-05-07 2024-05-09"


### PR DESCRIPTION
Currently, the index.html shows well except one bug.

```text
index.html:135 Uncaught TypeError: date.getAttribute is not a function
    at index.html:135:16
```

This is because both of `<calendar-date`> and `<calendar-multi>` blocks have the same id — "date", so changed the id of <calendar-multi>` to "multi", from "date".

Screenshot:

![Screenshot 2025-02-06 at 14 01 57](https://github.com/user-attachments/assets/62323025-ea82-4455-a419-092bbca1ef70)


