### PR TITLE
add `today` attribute

### DIFF
--- a/docs/src/pages/components/calendar-date.astro
+++ b/docs/src/pages/components/calendar-date.astro
@@ -68,6 +68,13 @@ import Link from "../../components/Link.astro";
       <td><code>""</code></td>
     </tr>
     <tr>
+      <td><code>today</code></td>
+      <td><code>today</code></td>
+      <td>The date that is considered today</td>
+      <td><code>string</code></td>
+      <td><code>""</code></td>
+    </tr>
+    <tr>
       <td><code>focusedDate</code></td>
       <td><code>focused-date</code></td>
       <td>The date that is considered "focused" by the calendar</td>

--- a/docs/src/pages/components/calendar-multi.astro
+++ b/docs/src/pages/components/calendar-multi.astro
@@ -68,6 +68,13 @@ import Link from "../../components/Link.astro";
       <td><code>""</code></td>
     </tr>
     <tr>
+      <td><code>today</code></td>
+      <td><code>today</code></td>
+      <td>The date that is considered today</td>
+      <td><code>string</code></td>
+      <td><code>""</code></td>
+    </tr>
+    <tr>
       <td><code>focusedDate</code></td>
       <td><code>focused-date</code></td>
       <td>The date that is considered "focused" by the calendar</td>

--- a/docs/src/pages/components/calendar-range.astro
+++ b/docs/src/pages/components/calendar-range.astro
@@ -72,6 +72,13 @@ import Link from "../../components/Link.astro";
       <td><code>""</code></td>
     </tr>
     <tr>
+      <td><code>today</code></td>
+      <td><code>today</code></td>
+      <td>The date that is considered today</td>
+      <td><code>string</code></td>
+      <td><code>""</code></td>
+    </tr>
+    <tr>
       <td><code>focusedDate</code></td>
       <td><code>focused-date</code></td>
       <td>The date that is considered "focused" by the calendar</td>

--- a/src/calendar-base/calendar-base.tsx
+++ b/src/calendar-base/calendar-base.tsx
@@ -92,6 +92,10 @@ export const props = {
     type: String,
     value: "",
   },
+  today: {
+    type: String,
+    value: "",
+  },
   isDateDisallowed: {
     type: Function,
     value: (date: Date) => false,

--- a/src/calendar-base/useCalendarBase.ts
+++ b/src/calendar-base/useCalendarBase.ts
@@ -8,7 +8,7 @@ import {
 } from "atomico";
 import { PlainDate, PlainYearMonth } from "../utils/temporal.js";
 import { useDateProp, useDateFormatter } from "../utils/hooks.js";
-import { clamp, toDate, today } from "../utils/date.js";
+import { clamp, toDate, getToday } from "../utils/date.js";
 
 export type Pagination = "single" | "months";
 
@@ -118,7 +118,7 @@ export function useCalendarBase({
   const dispatch = useEvent("change");
 
   const focusedDate = useMemo(
-    () => clamp(focusedDateProp ?? today(), min, max),
+    () => clamp(focusedDateProp ?? getToday(), min, max),
     [focusedDateProp, min, max]
   );
 

--- a/src/calendar-base/useCalendarBase.ts
+++ b/src/calendar-base/useCalendarBase.ts
@@ -114,12 +114,13 @@ export function useCalendarBase({
 }: CalendarBaseOptions) {
   const [min] = useDateProp("min");
   const [max] = useDateProp("max");
+  const [today] = useDateProp("today");
   const dispatchFocusDay = useEvent<Date>("focusday");
   const dispatch = useEvent("change");
 
   const focusedDate = useMemo(
-    () => clamp(focusedDateProp ?? getToday(), min, max),
-    [focusedDateProp, min, max]
+    () => clamp(focusedDateProp ?? today ?? getToday(), min, max),
+    [focusedDateProp, today, min, max]
   );
 
   function goto(date: PlainDate) {
@@ -163,6 +164,7 @@ export function useCalendarBase({
     },
     min,
     max,
+    today,
     next,
     previous,
     focus,

--- a/src/calendar-date/calendar-date.test.tsx
+++ b/src/calendar-date/calendar-date.test.tsx
@@ -22,7 +22,7 @@ import { CalendarMonth } from "../calendar-month/calendar-month.js";
 import type { Pagination } from "../calendar-base/useCalendarBase.js";
 import { CalendarDate } from "./calendar-date.js";
 import { PlainDate, PlainYearMonth } from "../utils/temporal.js";
-import { today, toDate } from "../utils/date.js";
+import { getToday, toDate } from "../utils/date.js";
 
 type TestProps = {
   onchange: (e: Event) => void;
@@ -693,7 +693,7 @@ describe("CalendarDate", () => {
 
     it("defaults to today if no value set", async () => {
       const calendar = await mount(<Fixture />);
-      const todaysDate = toDate(today());
+      const todaysDate = toDate(getToday());
       const month = getMonth(calendar);
 
       const heading = getMonthHeading(month);

--- a/src/calendar-date/calendar-date.test.tsx
+++ b/src/calendar-date/calendar-date.test.tsx
@@ -30,6 +30,7 @@ type TestProps = {
   value: string;
   min: string;
   max: string;
+  today: string;
   children: VNodeAny;
   showOutsideDays: boolean;
   months: number;

--- a/src/calendar-month/CalendarMonthContext.ts
+++ b/src/calendar-month/CalendarMonthContext.ts
@@ -1,6 +1,6 @@
 import { createContext } from "atomico";
 import type { PlainDate, PlainYearMonth } from "../utils/temporal.js";
-import { today, type DaysOfWeek } from "../utils/date.js";
+import { getToday, type DaysOfWeek } from "../utils/date.js";
 
 interface CalendarContextBase {
   min?: PlainDate;
@@ -35,7 +35,7 @@ export type CalendarContextValue =
   | CalendarRangeContext
   | CalendarMultiContext;
 
-const t = today();
+const t = getToday();
 
 export const CalendarContext = createContext<CalendarContextValue>({
   type: "date",

--- a/src/calendar-month/CalendarMonthContext.ts
+++ b/src/calendar-month/CalendarMonthContext.ts
@@ -5,6 +5,7 @@ import { getToday, type DaysOfWeek } from "../utils/date.js";
 interface CalendarContextBase {
   min?: PlainDate;
   max?: PlainDate;
+  today?: PlainDate;
   firstDayOfWeek: DaysOfWeek;
   isDateDisallowed?: (date: Date) => boolean;
   getDayParts?: (date: Date) => string;

--- a/src/calendar-month/calendar-month.test.tsx
+++ b/src/calendar-month/calendar-month.test.tsx
@@ -11,6 +11,7 @@ import {
   getSelectedDays,
   click,
   sendShiftPress,
+  getTodayButton,
 } from "../utils/test.js";
 import {
   CalendarContext,
@@ -565,6 +566,17 @@ describe("CalendarMonth", () => {
       await clickDay(month, "30 January");
       expect(spy.count).to.eq(1);
       expect(spy.last[0].detail.toString()).to.eq("2020-01-30");
+    });
+  });
+
+  describe("today support", () => {
+    it("supports today date", async () => {
+      const month = await mount(
+        <Fixture focusedDate={PlainDate.from("2020-01-01")} today={PlainDate.from("2020-01-02")} />
+      );
+
+      const todayButton = getTodayButton(month);
+      expect(todayButton).to.have.attribute("aria-label", "2 January");
     });
   });
 

--- a/src/calendar-month/calendar-month.test.tsx
+++ b/src/calendar-month/calendar-month.test.tsx
@@ -21,7 +21,7 @@ import {
 import { CalendarMonth } from "../calendar-month/calendar-month.js";
 import { fixture } from "atomico/test-dom";
 import { PlainDate } from "../utils/temporal.js";
-import { toDate, today } from "../utils/date.js";
+import { toDate, getToday } from "../utils/date.js";
 
 type MonthContextInstance = InstanceType<typeof CalendarContext>;
 
@@ -40,7 +40,7 @@ const isWeekend = (date: Date) => date.getDay() === 0 || date.getDay() === 6;
 function Fixture({
   onselectday,
   onfocusday,
-  focusedDate = today(),
+  focusedDate = getToday(),
   dir,
   type = "date",
   formatWeekday = "narrow",
@@ -199,7 +199,7 @@ describe("CalendarMonth", () => {
       it("marks today", async () => {
         const month = await mount(<Fixture />);
 
-        const todaysDate = toDate(today()).toLocaleDateString("en-GB", {
+        const todaysDate = toDate(getToday()).toLocaleDateString("en-GB", {
           day: "numeric",
           month: "long",
         });

--- a/src/calendar-month/useCalendarMonth.ts
+++ b/src/calendar-month/useCalendarMonth.ts
@@ -33,13 +33,14 @@ export function useCalendarMonth({ props, context }: UseCalendarMonthOptions) {
     isDateDisallowed,
     min,
     max,
+    today,
     page,
     locale,
     focusedDate,
     formatWeekday,
   } = context;
 
-  const todaysDate = getToday();
+  const todaysDate = today ?? getToday();
   const daysLong = useDayNames(longDayOptions, firstDayOfWeek, locale);
   const visibleDayOptions = useMemo(
     () => ({ weekday: formatWeekday }),

--- a/src/calendar-month/useCalendarMonth.ts
+++ b/src/calendar-month/useCalendarMonth.ts
@@ -6,7 +6,7 @@ import {
   getViewOfMonth,
   startOfWeek,
   toDate,
-  today,
+  getToday,
 } from "../utils/date.js";
 import type { PlainDate } from "../utils/temporal.js";
 import type { CalendarContextValue } from "./CalendarMonthContext.js";
@@ -39,7 +39,7 @@ export function useCalendarMonth({ props, context }: UseCalendarMonthOptions) {
     formatWeekday,
   } = context;
 
-  const todaysDate = today();
+  const todaysDate = getToday();
   const daysLong = useDayNames(longDayOptions, firstDayOfWeek, locale);
   const visibleDayOptions = useMemo(
     () => ({ weekday: formatWeekday }),

--- a/src/calendar-multi/calendar-multi.test.tsx
+++ b/src/calendar-multi/calendar-multi.test.tsx
@@ -22,6 +22,7 @@ type TestProps = {
   value: string;
   min: string;
   max: string;
+  today: string;
   months?: number;
   children?: VNodeAny;
 };

--- a/src/calendar-range/calendar-range.test.tsx
+++ b/src/calendar-range/calendar-range.test.tsx
@@ -25,6 +25,7 @@ type TestProps = {
   value: string;
   min: string;
   max: string;
+  today: string;
   tentative?: string;
   focusedDate?: string;
   months?: number;

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -2,7 +2,7 @@ import { PlainDate, type PlainYearMonth } from "./temporal.js";
 
 export type DaysOfWeek = 0 | 1 | 2 | 3 | 4 | 5 | 6;
 
-export function today() {
+export function getToday() {
   const d = new Date();
   return new PlainDate(d.getFullYear(), d.getMonth() + 1, d.getDate());
 }

--- a/src/utils/test.ts
+++ b/src/utils/test.ts
@@ -143,6 +143,12 @@ export function getNextPageButton(calendar: CalendarInstance) {
   )!;
 }
 
+export function getTodayButton(month: MonthInstance) {
+  return month.shadowRoot!.querySelector<HTMLButtonElement>(
+    `button[part~="today"]`
+  )!;
+}
+
 export function getSelectedDays(month: MonthInstance) {
   return [
     ...month.shadowRoot!.querySelectorAll<HTMLButtonElement>(


### PR DESCRIPTION
With this pr, we can optionally use the `today` attribute, which helps dynamically set today.

```html
<calendar-date today="2025-01-01">
<calendar-multi today="2025-01-01">
<calendar-range today="2025-01-01">
```

- resolves https://github.com/WickyNilliams/cally/issues/73