### PR TITLE
chore: fix playwright version to 1.50.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8148,33 +8148,35 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.42.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.42.1.tgz",
-      "integrity": "sha512-PgwB03s2DZBcNRoW+1w9E+VkLBxweib6KTXM0M3tkiT4jVxKSi6PmVJ591J+0u10LUrgxB7dLRbiJqO5s2QPMg==",
+      "version": "1.50.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.50.1.tgz",
+      "integrity": "sha512-G8rwsOQJ63XG6BbKj2w5rHeavFjy5zynBA9zsJMMtBoe/Uf757oG12NXz6e6OirF7RCrTVAKFXbLmn1RbL7Qaw==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.42.1"
+        "playwright-core": "1.50.1"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       },
       "optionalDependencies": {
         "fsevents": "2.3.2"
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.42.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.42.1.tgz",
-      "integrity": "sha512-mxz6zclokgrke9p1vtdy/COWBH+eOZgYUVVU34C73M+4j4HLlQJHtfcqiqqxpP0o8HhMkflvfbquLX5dg6wlfA==",
+      "version": "1.50.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.50.1.tgz",
+      "integrity": "sha512-ra9fsNWayuYumt+NiM069M6OkcRb1FZSK8bgi66AtpFoWkg2+y0bJSNmkFrWhMbEBbVKC/EruAHH3g0zmtwGmQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       }
     },
     "node_modules/playwright/node_modules/fsevents": {

--- a/package.json
+++ b/package.json
@@ -53,5 +53,11 @@
     "typescript": "^5.3.3",
     "vite": "^5.1.4",
     "vite-plugin-dts": "^3.7.3"
+  },
+  "overrides": {
+    "playwright": {
+      ".": "1.50.1",
+      "@web/test-runner-playwright": "0.11.0"
+    }
   }
 }


### PR DESCRIPTION
# Background

Old `playwright` versions cause installation failure on the latest Ubuntu (24.04). This makes CI workflow fail.

One of Cally's dependencies is `@web/test-runner-playwright`, which depends on `"playwright": ^1.22.2`, which — actually — can be "1.50.1" because of the caret(^). As it turned out, it's an easy fix that requires recreating a package-lock.json.

# Options

We have several options:

- remove package-lock.json and run `npm install`
- add `overrides` property in package.json
- modify package-lock.json directly, which is not recommended though

I chose the second one because the whole update of package-lock.json causes another dependency problem. See my trial: https://github.com/roeniss/cally/actions/runs/13199654534/job/36848583565?pr=3#step:5:30

# Summary

I succeeded CI (test.yml) with this patch: https://github.com/roeniss/cally/actions/runs/13199881264/job/36849264104?pr=3

this will also help https://github.com/WickyNilliams/cally/pull/75 and https://github.com/WickyNilliams/cally/pull/78
