### PR TITLE
add numbered parts for each day

### DIFF
--- a/docs/src/pages/components/calendar-month.astro
+++ b/docs/src/pages/components/calendar-month.astro
@@ -127,7 +127,35 @@ import Link from "../../components/Link.astro";
     </tr>
     <tr>
       <td><code>day</code></td>
-      <td>The buttons corresponding to each day in the grid</td>
+      <td>The buttons and headings corresponding to each day in the grid</td>
+    </tr>
+    <tr>
+      <td><code>day-0</code></td>
+      <td>The buttons and headings corresponding to Sunday</td>
+    </tr>
+    <tr>
+      <td><code>day-1</code></td>
+      <td>The buttons and headings corresponding to Monday</td>
+    </tr>
+    <tr>
+      <td><code>day-2</code></td>
+      <td>The buttons and headings corresponding to Tuesday</td>
+    </tr>
+    <tr>
+      <td><code>day-3</code></td>
+      <td>The buttons and headings corresponding to Wednesday</td>
+    </tr>
+    <tr>
+      <td><code>day-4</code></td>
+      <td>The buttons and headings corresponding to Thursday</td>
+    </tr>
+    <tr>
+      <td><code>day-5</code></td>
+      <td>The buttons and headings corresponding to Friday</td>
+    </tr>
+    <tr>
+      <td><code>day-6</code></td>
+      <td>The buttons and headings corresponding to Saturday</td>
     </tr>
     <tr>
       <td><code>selected</code></td>

--- a/src/calendar-month/calendar-month.test.tsx
+++ b/src/calendar-month/calendar-month.test.tsx
@@ -572,7 +572,10 @@ describe("CalendarMonth", () => {
   describe("today support", () => {
     it("supports today date", async () => {
       const month = await mount(
-        <Fixture focusedDate={PlainDate.from("2020-01-01")} today={PlainDate.from("2020-01-02")} />
+        <Fixture
+          focusedDate={PlainDate.from("2020-01-01")}
+          today={PlainDate.from("2020-01-02")}
+        />
       );
 
       const todayButton = getTodayButton(month);
@@ -658,6 +661,42 @@ describe("CalendarMonth", () => {
       expect(visualHeadings[4]).to.have.trimmed.text("Fri");
       expect(visualHeadings[5]).to.have.trimmed.text("Sat");
       expect(visualHeadings[6]).to.have.trimmed.text("Sun");
+    });
+
+    it("renders parts for each day corresponding to day number", async () => {
+      const mapToDayNumber = (firstDayOfWeek: number, i: number) =>
+        (i + firstDayOfWeek) % 7;
+
+      const firstDayOfWeek = 2;
+      const month = await mount(
+        <Fixture
+          focusedDate={PlainDate.from("2020-01-15")}
+          firstDayOfWeek={firstDayOfWeek}
+        />
+      );
+      const grid = getGrid(month);
+
+      const headings = grid.querySelectorAll("th");
+      const days = grid.rows[2]!.querySelectorAll("button");
+
+      // sanity check
+      expect(headings.length).to.eq(7);
+      expect(days.length).to.eq(7);
+
+      for (let i = 0; i < 7; i++) {
+        const heading = headings[i]!;
+        const day = days[i]!;
+        const part = `day-${mapToDayNumber(firstDayOfWeek, i)}`;
+
+        expect(heading.part.contains(part)).to.eq(
+          true,
+          `expected part to contain "${part}", got "${heading.part}"`
+        );
+        expect(day.part.contains(part)).to.eq(
+          true,
+          `expected part to contain "${part}, got "${day.part}"`
+        );
+      }
     });
   });
 });

--- a/src/calendar-month/calendar-month.tsx
+++ b/src/calendar-month/calendar-month.tsx
@@ -4,6 +4,9 @@ import { useCalendarMonth } from "./useCalendarMonth.js";
 import { CalendarContext } from "./CalendarMonthContext.js";
 import { toDate } from "../utils/date.js";
 
+const mapToDayNumber = (firstDayOfWeek: number, i: number) =>
+  (i + firstDayOfWeek) % 7;
+
 export const CalendarMonth = c(
   (
     props
@@ -30,7 +33,10 @@ export const CalendarMonth = c(
           <thead>
             <tr part="tr head">
               {calendar.daysLong.map((dayName, i) => (
-                <th part="th" scope="col">
+                <th
+                  part={`th day day-${mapToDayNumber(context.firstDayOfWeek, i)}`}
+                  scope="col"
+                >
                   <span class="vh">{dayName}</span>
                   <span aria-hidden="true">{calendar.daysVisible[i]}</span>
                 </th>

--- a/src/calendar-month/useCalendarMonth.ts
+++ b/src/calendar-month/useCalendarMonth.ts
@@ -142,7 +142,7 @@ export function useCalendarMonth({ props, context }: UseCalendarMonthOptions) {
     }
 
     // prettier-ignore
-    const commonParts = `button day ${
+    const commonParts = `button day day-${asDate.getDay()} ${
       // we don't want outside days to ever be shown as selected
       isInMonth ? (isSelected ? "selected" : "") : "outside"
     } ${


### PR DESCRIPTION
Fixes #74

@roeniss I think this will do what you wanted:

```html
<style>
::part(day-0) {
  color: red;
}
</style>
<calendar-date>
  <calendar-month></calendar-month>
</calendar-date>
```

As well as the numbered day parts, i added `day` to the table `th`, so you can target both in one style rule. If you want to style one differently to the other you can combine parts like:

```css
::part(th day-0) {
  ...
}
::part(button day-0) {
  ...
}
```

Let me know if this is good for you!