### PR TITLE
Add configurable calendar-heading component

### DIFF
--- a/docs/src/pages/components/calendar-heading.astro
+++ b/docs/src/pages/components/calendar-heading.astro
@@ -1,0 +1,83 @@
+---
+import ApiLayout from "../../layouts/ApiLayout.astro";
+import Table from "../../components/Table.astro";
+import Heading from "../../components/Heading.astro";
+import Link from "../../components/Link.astro";
+import Example from "../../components/Example.astro";
+---
+
+<ApiLayout
+  heading="<calendar-heading>"
+  meta={{
+    title: "<calendar-heading> API",
+    description:
+      "The calendar-heading component displays a formatted date or date range heading for the calendar. Find out how to use its properties and styling options.",
+  }}
+>
+  <p>
+    This component displays a formatted heading showing the current month and/or
+    year of the calendar. It should not be used alone, but placed in the
+    <code>heading</code> slot of
+    one of
+    <Link href="/components/calendar-date/"
+      ><code>{`<calendar-date>`}</code></Link
+    >,
+    <Link href="/components/calendar-range/"
+      ><code>{`<calendar-range>`}</code></Link
+    >,
+    <Link href="/components/calendar-multi/"
+      ><code>{`<calendar-multi>`}</code></Link
+    > or
+    <Link href="/components/calendar-month/"
+      ><code>{`<calendar-month>`}</code></Link
+    >.
+  </p>
+
+  <Example css="calendar-month::part(heading) { display: none; }">
+    <calendar-date>
+      <calendar-heading
+        slot="heading"
+        year="numeric"
+        month="long"
+      ></calendar-heading>
+      <calendar-month></calendar-month>
+    </calendar-date>
+  </Example>
+
+  <Heading level={2}>Properties and attributes</Heading>
+
+  <Table>
+    <tr slot="head">
+      <th>Property</th>
+      <th>Attribute</th>
+      <th>Description</th>
+      <th>Type</th>
+      <th>Default</th>
+    </tr>
+
+    <tr>
+      <td><code>year</code></td>
+      <td><code>year</code></td>
+      <td>
+        How to display the year. When omitted, the year is not shown.
+      </td>
+      <td><code>"numeric" | "2-digit"</code></td>
+      <td><code>undefined</code></td>
+    </tr>
+    <tr>
+      <td><code>month</code></td>
+      <td><code>month</code></td>
+      <td>
+        How to display the month. When omitted, the month is not shown.
+      </td>
+      <td><code>"numeric" | "2-digit" | "long" | "short" | "narrow"</code></td>
+      <td><code>undefined</code></td>
+    </tr>
+  </Table>
+</ApiLayout>
+
+<style is:global>
+  calendar-date {
+    margin-inline: auto;
+  }
+</style>

--- a/docs/src/pages/components/calendar-month.astro
+++ b/docs/src/pages/components/calendar-month.astro
@@ -240,6 +240,15 @@ import Link from "../../components/Link.astro";
       <th>Description</th>
     </tr>
     <tr>
+      <td><code>heading</code></td>
+      <td>
+        Replaces the default month heading. Accepts a
+        <Link href="/components/calendar-heading/"
+          ><code>{`<calendar-heading>`}</code></Link
+        > or custom content.
+      </td>
+    </tr>
+    <tr>
       <td>weeknumber</td>
       <td>
         If week numbers are shown, this slot holds the heading for the column.

--- a/docs/src/pages/components/index.astro
+++ b/docs/src/pages/components/index.astro
@@ -48,5 +48,10 @@ import Link from "../../components/Link.astro";
         ><code>{`<calendar-select-year>`}</code></Link
       >
     </li>
+    <li>
+      <Link href="/components/calendar-heading/"
+        ><code>{`<calendar-heading>`}</code></Link
+      >
+    </li>
   </ul>
 </Layout>

--- a/index.html
+++ b/index.html
@@ -80,6 +80,12 @@
           }
         }
       }
+
+      #custom-heading {
+        calendar-month::part(heading) {
+          display: none;
+        }
+      }
     </style>
   </head>
   <body>
@@ -145,6 +151,13 @@
       <calendar-month></calendar-month>
       <calendar-month offset="1"></calendar-month>
     </calendar-multi>
+
+    <h2>Custom Heading</h2>
+    <calendar-date id="custom-heading" page-by="single">
+      <calendar-heading slot="heading" month="long" year="numeric"></calendar-heading>
+      <calendar-month></calendar-month>
+    </calendar-multi>
+
 
     <script type="module">
       import "./src/index.ts";

--- a/src/calendar-base/calendar-base.tsx
+++ b/src/calendar-base/calendar-base.tsx
@@ -5,14 +5,13 @@ import {
   type CalendarMultiContext,
   type CalendarRangeContext,
 } from "../calendar-month/CalendarMonthContext.js";
+import { CalendarHeading } from "../calendar-heading/calendar-heading.js";
 import { reset, vh } from "../utils/styles.js";
-import { toDate, type DaysOfWeek } from "../utils/date.js";
+import { type DaysOfWeek } from "../utils/date.js";
 import type { PlainDate } from "../utils/temporal.js";
 import type { Pagination } from "./useCalendarBase.js";
 
 interface CalendarBaseProps {
-  format: Intl.DateTimeFormat;
-  formatVerbose: Intl.DateTimeFormat;
   pageBy: Pagination;
   previous?: () => void;
   next?: () => void;
@@ -44,9 +43,6 @@ function Button(props: {
 export function CalendarBase(
   props: CalendarDateProps | CalendarRangeProps | CalendarMultiProps
 ) {
-  const start = toDate(props.page.start);
-  const end = toDate(props.page.end);
-
   return (
     <CalendarContext
       value={props}
@@ -55,9 +51,14 @@ export function CalendarBase(
       onhoverday={props.onHover}
     >
       <div role="group" aria-labelledby="h" part="container">
-        <div id="h" class="vh" aria-live="polite" aria-atomic="true">
-          {props.formatVerbose.formatRange(start, end)}
-        </div>
+        <CalendarHeading
+          month="long"
+          year="numeric"
+          id="h"
+          class="vh"
+          aria-live="polite"
+          aria-atomic="true"
+        />
 
         <div part="header">
           <Button name="previous" onclick={props.previous}>
@@ -65,7 +66,7 @@ export function CalendarBase(
           </Button>
 
           <slot part="heading" name="heading">
-            <div aria-hidden="true">{props.format.formatRange(start, end)}</div>
+            <CalendarHeading year="numeric" aria-hidden="true" />
           </slot>
 
           <Button name="next" onclick={props.next}>

--- a/src/calendar-base/useCalendarBase.ts
+++ b/src/calendar-base/useCalendarBase.ts
@@ -1,6 +1,7 @@
-import { useState, useEvent, useHost, useEffect, useMemo } from "atomico";
+import { useState, useEvent, useHost, useEffect, useMemo, useProvider } from "atomico";
+import { CalendarHeadingContext } from "../calendar-heading/CalendarHeadingContext.js";
 import { PlainDate, PlainYearMonth } from "../utils/temporal.js";
-import { useDateProp, useDateFormatter } from "../utils/hooks.js";
+import { useDateProp } from "../utils/hooks.js";
 import { clamp, toDate, getToday } from "../utils/date.js";
 
 export type Pagination = "single" | "months";
@@ -12,9 +13,6 @@ type CalendarBaseOptions = {
   focusedDate: PlainDate | undefined;
   setFocusedDate: (date: PlainDate) => void;
 };
-
-const formatOptions = { year: "numeric" } as const;
-const formatVerboseOptions = { year: "numeric", month: "long" } as const;
 
 function diffInMonths(a: PlainYearMonth, b: PlainYearMonth): number {
   return (b.year - a.year) * 12 + b.month - a.month;
@@ -136,6 +134,8 @@ export function useCalendarBase({
     goto,
   });
 
+  useProvider(CalendarHeadingContext, { type: "range", value: page, locale });
+
   const host = useHost();
   function focus(options?: CalendarFocusOptions) {
     const target = options?.target ?? "day";
@@ -151,8 +151,6 @@ export function useCalendarBase({
   }
 
   return {
-    format: useDateFormatter(formatOptions, locale),
-    formatVerbose: useDateFormatter(formatVerboseOptions, locale),
     page,
     focusedDate,
     dispatch,

--- a/src/calendar-date/calendar-date.test.tsx
+++ b/src/calendar-date/calendar-date.test.tsx
@@ -81,7 +81,7 @@ describe("CalendarDate", () => {
       });
 
       const heading = getCalendarHeading(calendar);
-      await expect.element(heading).toHaveTextContent(formatter.format(yearMonth));
+      await expect.poll(heading).toContain(formatter.format(yearMonth));
     });
 
     it("correctly labels a range of months", async () => {
@@ -100,15 +100,7 @@ describe("CalendarDate", () => {
         timeZone: "UTC",
       });
 
-      // Use poll() instead of toHaveTextContent() because the formatter output
-      // contains unicode characters (en-dash "–") that toHaveTextContent() normalizes
-      // differently, causing false negatives. poll() does direct string comparison.
-      await expect.poll(() => {
-        const group = calendar.shadowRoot!.querySelector(`[role="group"]`)!;
-        const labelledById = group.getAttribute("aria-labelledby")!;
-        const heading = calendar.shadowRoot!.getElementById(labelledById)!;
-        return heading.textContent;
-      }).toBe(formatter.formatRange(toDate(start), toDate(end)));
+      await expect.poll(getCalendarHeading(calendar)).toBe(formatter.formatRange(toDate(start), toDate(end)));
     });
   });
 
@@ -266,8 +258,8 @@ describe("CalendarDate", () => {
         ];
 
         await getNextPageButton(calendar).click();
-        await expect.element(getMonthHeading(first!)).toHaveTextContent("March");
-        await expect.element(getMonthHeading(second!)).toHaveTextContent("April");
+        await expect.poll(getMonthHeading(first!)).toContain("March");
+        await expect.poll(getMonthHeading(second!)).toContain("April");
       });
 
       it("updates page as user navigates dates", async () => {
@@ -289,53 +281,53 @@ describe("CalendarDate", () => {
 
         // move to feb, within page
         await userEvent.keyboard("{PageDown}");
-        await expect.element(getMonthHeading(first)).toHaveTextContent("January");
-        await expect.element(getMonthHeading(second)).toHaveTextContent("February");
+        await expect.poll(getMonthHeading(first)).toContain("January");
+        await expect.poll(getMonthHeading(second)).toContain("February");
 
         // move to march, out of page
         await userEvent.keyboard("{PageDown}");
-        await expect.element(getMonthHeading(first)).toHaveTextContent("March");
-        await expect.element(getMonthHeading(second)).toHaveTextContent("April");
+        await expect.poll(getMonthHeading(first)).toContain("March");
+        await expect.poll(getMonthHeading(second)).toContain("April");
 
         // move to april, should be on same page
         await userEvent.keyboard("{PageDown}");
-        await expect.element(getMonthHeading(first)).toHaveTextContent("March");
-        await expect.element(getMonthHeading(second)).toHaveTextContent("April");
+        await expect.poll(getMonthHeading(first)).toContain("March");
+        await expect.poll(getMonthHeading(second)).toContain("April");
 
         // move to march, within page
         await userEvent.keyboard("{PageUp}");
-        await expect.element(getMonthHeading(first)).toHaveTextContent("March");
-        await expect.element(getMonthHeading(second)).toHaveTextContent("April");
+        await expect.poll(getMonthHeading(first)).toContain("March");
+        await expect.poll(getMonthHeading(second)).toContain("April");
 
         // move to feb, out of page
         await userEvent.keyboard("{PageUp}");
-        await expect.element(getMonthHeading(first)).toHaveTextContent("January");
-        await expect.element(getMonthHeading(second)).toHaveTextContent("February");
+        await expect.poll(getMonthHeading(first)).toContain("January");
+        await expect.poll(getMonthHeading(second)).toContain("February");
 
         // move to jan, within page
         await userEvent.keyboard("{PageUp}");
-        await expect.element(getMonthHeading(first)).toHaveTextContent("January");
-        await expect.element(getMonthHeading(second)).toHaveTextContent("February");
+        await expect.poll(getMonthHeading(first)).toContain("January");
+        await expect.poll(getMonthHeading(second)).toContain("February");
 
         // move to dec, out of page
         await userEvent.keyboard("{PageUp}");
-        await expect.element(getMonthHeading(first)).toHaveTextContent("November");
-        await expect.element(getMonthHeading(second)).toHaveTextContent("December");
+        await expect.poll(getMonthHeading(first)).toContain("November");
+        await expect.poll(getMonthHeading(second)).toContain("December");
 
         // sanity check
         expect(calendar.focusedDate).toBe("2019-12-01");
 
         // move one year ahead
         await sendShiftPress("PageDown");
-        await expect.element(getCalendarVisibleHeading(calendar)).toHaveTextContent("2020");
-        await expect.element(getMonthHeading(first)).toHaveTextContent("November");
-        await expect.element(getMonthHeading(second)).toHaveTextContent("December");
+        await expect.poll(getCalendarVisibleHeading(calendar)).toContain("2020");
+        await expect.poll(getMonthHeading(first)).toContain("November");
+        await expect.poll(getMonthHeading(second)).toContain("December");
 
         // move one year back
         await sendShiftPress("PageUp");
-        await expect.element(getCalendarVisibleHeading(calendar)).toHaveTextContent("2019");
-        await expect.element(getMonthHeading(first)).toHaveTextContent("November");
-        await expect.element(getMonthHeading(second)).toHaveTextContent("December");
+        await expect.poll(getCalendarVisibleHeading(calendar)).toContain("2019");
+        await expect.poll(getMonthHeading(first)).toContain("November");
+        await expect.poll(getMonthHeading(second)).toContain("December");
       });
 
       it("pages by number of months", async () => {
@@ -354,24 +346,24 @@ describe("CalendarDate", () => {
         ];
 
         await next.click();
-        await expect.element(getMonthHeading(first)).toHaveTextContent("March");
-        await expect.element(getMonthHeading(second)).toHaveTextContent("April");
+        await expect.poll(getMonthHeading(first)).toContain("March");
+        await expect.poll(getMonthHeading(second)).toContain("April");
 
         await next.click();
-        await expect.element(getMonthHeading(first)).toHaveTextContent("May");
-        await expect.element(getMonthHeading(second)).toHaveTextContent("June");
+        await expect.poll(getMonthHeading(first)).toContain("May");
+        await expect.poll(getMonthHeading(second)).toContain("June");
 
         await prev.click();
-        await expect.element(getMonthHeading(first)).toHaveTextContent("March");
-        await expect.element(getMonthHeading(second)).toHaveTextContent("April");
+        await expect.poll(getMonthHeading(first)).toContain("March");
+        await expect.poll(getMonthHeading(second)).toContain("April");
 
         await prev.click();
-        await expect.element(getMonthHeading(first)).toHaveTextContent("January");
-        await expect.element(getMonthHeading(second)).toHaveTextContent("February");
+        await expect.poll(getMonthHeading(first)).toContain("January");
+        await expect.poll(getMonthHeading(second)).toContain("February");
 
         await prev.click();
-        await expect.element(getMonthHeading(first)).toHaveTextContent("November");
-        await expect.element(getMonthHeading(second)).toHaveTextContent("December");
+        await expect.poll(getMonthHeading(first)).toContain("November");
+        await expect.poll(getMonthHeading(second)).toContain("December");
       });
 
       it("handles focused date prop changing", async () => {
@@ -389,30 +381,30 @@ describe("CalendarDate", () => {
         // one year ahead
         calendar.focusedDate = "2021-01-01";
         await nextFrame();
-        await expect.element(getMonthHeading(first)).toHaveTextContent("January");
-        await expect.element(getMonthHeading(second)).toHaveTextContent("February");
-        await expect.element(getCalendarVisibleHeading(calendar)).toHaveTextContent("2021");
+        await expect.poll(getMonthHeading(first)).toContain("January");
+        await expect.poll(getMonthHeading(second)).toContain("February");
+        await expect.poll(getCalendarVisibleHeading(calendar)).toContain("2021");
 
         // one month outside of page
         calendar.focusedDate = "2021-03-01";
         await nextFrame();
-        await expect.element(getMonthHeading(first)).toHaveTextContent("March");
-        await expect.element(getMonthHeading(second)).toHaveTextContent("April");
-        await expect.element(getCalendarVisibleHeading(calendar)).toHaveTextContent("2021");
+        await expect.poll(getMonthHeading(first)).toContain("March");
+        await expect.poll(getMonthHeading(second)).toContain("April");
+        await expect.poll(getCalendarVisibleHeading(calendar)).toContain("2021");
 
         // a few months ahead
         calendar.focusedDate = "2021-05-01";
         await nextFrame();
-        await expect.element(getMonthHeading(first)).toHaveTextContent("May");
-        await expect.element(getMonthHeading(second)).toHaveTextContent("June");
-        await expect.element(getCalendarVisibleHeading(calendar)).toHaveTextContent("2021");
+        await expect.poll(getMonthHeading(first)).toContain("May");
+        await expect.poll(getMonthHeading(second)).toContain("June");
+        await expect.poll(getCalendarVisibleHeading(calendar)).toContain("2021");
 
         // a few months back
         calendar.focusedDate = "2020-12-01";
         await nextFrame();
-        await expect.element(getMonthHeading(first)).toHaveTextContent("November");
-        await expect.element(getMonthHeading(second)).toHaveTextContent("December");
-        await expect.element(getCalendarVisibleHeading(calendar)).toHaveTextContent("2020");
+        await expect.poll(getMonthHeading(first)).toContain("November");
+        await expect.poll(getMonthHeading(second)).toContain("December");
+        await expect.poll(getCalendarVisibleHeading(calendar)).toContain("2020");
       });
     });
 
@@ -437,55 +429,55 @@ describe("CalendarDate", () => {
 
         // move to feb, within page
         await userEvent.keyboard("{PageDown}");
-        await expect.element(getMonthHeading(first)).toHaveTextContent("January");
-        await expect.element(getMonthHeading(second)).toHaveTextContent("February");
+        await expect.poll(getMonthHeading(first)).toContain("January");
+        await expect.poll(getMonthHeading(second)).toContain("February");
 
         // move to march, out of page
         await userEvent.keyboard("{PageDown}");
-        await expect.element(getMonthHeading(first)).toHaveTextContent("February");
-        await expect.element(getMonthHeading(second)).toHaveTextContent("March");
+        await expect.poll(getMonthHeading(first)).toContain("February");
+        await expect.poll(getMonthHeading(second)).toContain("March");
 
         // move to april, should be on same page
         await userEvent.keyboard("{PageDown}");
-        await expect.element(getMonthHeading(first)).toHaveTextContent("March");
-        await expect.element(getMonthHeading(second)).toHaveTextContent("April");
+        await expect.poll(getMonthHeading(first)).toContain("March");
+        await expect.poll(getMonthHeading(second)).toContain("April");
 
         // move to march, within page
         await userEvent.keyboard("{PageUp}");
-        await expect.element(getMonthHeading(first)).toHaveTextContent("March");
-        await expect.element(getMonthHeading(second)).toHaveTextContent("April");
+        await expect.poll(getMonthHeading(first)).toContain("March");
+        await expect.poll(getMonthHeading(second)).toContain("April");
 
         // move to feb, out of page
         await userEvent.keyboard("{PageUp}");
-        await expect.element(getMonthHeading(first)).toHaveTextContent("February");
-        await expect.element(getMonthHeading(second)).toHaveTextContent("March");
+        await expect.poll(getMonthHeading(first)).toContain("February");
+        await expect.poll(getMonthHeading(second)).toContain("March");
 
         // move to jan, within page
         await userEvent.keyboard("{PageUp}");
-        await expect.element(getMonthHeading(first)).toHaveTextContent("January");
-        await expect.element(getMonthHeading(second)).toHaveTextContent("February");
+        await expect.poll(getMonthHeading(first)).toContain("January");
+        await expect.poll(getMonthHeading(second)).toContain("February");
 
         // move to dec, out of page
         await userEvent.keyboard("{PageUp}");
-        await expect.element(getMonthHeading(first)).toHaveTextContent("December");
-        await expect.element(getMonthHeading(second)).toHaveTextContent("January");
+        await expect.poll(getMonthHeading(first)).toContain("December");
+        await expect.poll(getMonthHeading(second)).toContain("January");
 
         // sanity check
         expect(calendar.focusedDate).toBe("2019-12-01");
 
         // move one year ahead
         await sendShiftPress("PageDown");
-        await expect.element(getCalendarVisibleHeading(calendar)).toHaveTextContent(/2020/);
-        await expect.element(getCalendarVisibleHeading(calendar)).toHaveTextContent(/2021/);
-        await expect.element(getMonthHeading(first)).toHaveTextContent("December");
-        await expect.element(getMonthHeading(second)).toHaveTextContent("January");
+        await expect.poll(getCalendarVisibleHeading(calendar)).toMatch(/2020/);
+        await expect.poll(getCalendarVisibleHeading(calendar)).toMatch(/2021/);
+        await expect.poll(getMonthHeading(first)).toContain("December");
+        await expect.poll(getMonthHeading(second)).toContain("January");
 
         // move one year back
         await sendShiftPress("PageUp");
-        await expect.element(getMonthHeading(first)).toHaveTextContent("December");
-        await expect.element(getCalendarVisibleHeading(calendar)).toHaveTextContent(/2019/);
-        await expect.element(getCalendarVisibleHeading(calendar)).toHaveTextContent(/2020/);
-        await expect.element(getMonthHeading(second)).toHaveTextContent("January");
+        await expect.poll(getMonthHeading(first)).toContain("December");
+        await expect.poll(getCalendarVisibleHeading(calendar)).toMatch(/2019/);
+        await expect.poll(getCalendarVisibleHeading(calendar)).toMatch(/2020/);
+        await expect.poll(getMonthHeading(second)).toContain("January");
       });
 
       it("pages by single month", async () => {
@@ -504,24 +496,24 @@ describe("CalendarDate", () => {
         const prev = getPrevPageButton(calendar);
 
         await next.click();
-        await expect.element(getMonthHeading(first)).toHaveTextContent("February");
-        await expect.element(getMonthHeading(second)).toHaveTextContent("March");
+        await expect.poll(getMonthHeading(first)).toContain("February");
+        await expect.poll(getMonthHeading(second)).toContain("March");
 
         await next.click();
-        await expect.element(getMonthHeading(first)).toHaveTextContent("March");
-        await expect.element(getMonthHeading(second)).toHaveTextContent("April");
+        await expect.poll(getMonthHeading(first)).toContain("March");
+        await expect.poll(getMonthHeading(second)).toContain("April");
 
         await prev.click();
-        await expect.element(getMonthHeading(first)).toHaveTextContent("February");
-        await expect.element(getMonthHeading(second)).toHaveTextContent("March");
+        await expect.poll(getMonthHeading(first)).toContain("February");
+        await expect.poll(getMonthHeading(second)).toContain("March");
 
         await prev.click();
-        await expect.element(getMonthHeading(first)).toHaveTextContent("January");
-        await expect.element(getMonthHeading(second)).toHaveTextContent("February");
+        await expect.poll(getMonthHeading(first)).toContain("January");
+        await expect.poll(getMonthHeading(second)).toContain("February");
 
         await prev.click();
-        await expect.element(getMonthHeading(first)).toHaveTextContent("December");
-        await expect.element(getMonthHeading(second)).toHaveTextContent("January");
+        await expect.poll(getMonthHeading(first)).toContain("December");
+        await expect.poll(getMonthHeading(second)).toContain("January");
       });
 
       it("pages by single month with 12 months", async () => {
@@ -547,23 +539,23 @@ describe("CalendarDate", () => {
 
         // with page-by="single", 12 months starting from June
         // should show Jun-May, not snap to Jan-Dec
-        await expect.element(getMonthHeading(first)).toHaveTextContent("June");
-        await expect.element(getMonthHeading(last)).toHaveTextContent("May");
+        await expect.poll(getMonthHeading(first)).toContain("June");
+        await expect.poll(getMonthHeading(last)).toContain("May");
 
         const next = getNextPageButton(calendar);
         const prev = getPrevPageButton(calendar);
 
         await next.click();
-        await expect.element(getMonthHeading(first)).toHaveTextContent("July");
-        await expect.element(getMonthHeading(last)).toHaveTextContent("June");
+        await expect.poll(getMonthHeading(first)).toContain("July");
+        await expect.poll(getMonthHeading(last)).toContain("June");
 
         await prev.click();
-        await expect.element(getMonthHeading(first)).toHaveTextContent("June");
-        await expect.element(getMonthHeading(last)).toHaveTextContent("May");
+        await expect.poll(getMonthHeading(first)).toContain("June");
+        await expect.poll(getMonthHeading(last)).toContain("May");
 
         await prev.click();
-        await expect.element(getMonthHeading(first)).toHaveTextContent("May");
-        await expect.element(getMonthHeading(last)).toHaveTextContent("April");
+        await expect.poll(getMonthHeading(first)).toContain("May");
+        await expect.poll(getMonthHeading(last)).toContain("April");
       });
 
       it("handles focused date prop changing", async () => {
@@ -581,31 +573,31 @@ describe("CalendarDate", () => {
         // one year ahead
         calendar.focusedDate = "2021-01-01";
         await nextFrame();
-        await expect.element(getMonthHeading(first)).toHaveTextContent("January");
-        await expect.element(getMonthHeading(second)).toHaveTextContent("February");
-        await expect.element(getCalendarVisibleHeading(calendar)).toHaveTextContent("2021");
+        await expect.poll(getMonthHeading(first)).toContain("January");
+        await expect.poll(getMonthHeading(second)).toContain("February");
+        await expect.poll(getCalendarVisibleHeading(calendar)).toContain("2021");
 
         // one month outside of page
         calendar.focusedDate = "2021-03-01";
         await nextFrame();
-        await expect.element(getMonthHeading(first)).toHaveTextContent("February");
-        await expect.element(getMonthHeading(second)).toHaveTextContent("March");
-        await expect.element(getCalendarVisibleHeading(calendar)).toHaveTextContent("2021");
+        await expect.poll(getMonthHeading(first)).toContain("February");
+        await expect.poll(getMonthHeading(second)).toContain("March");
+        await expect.poll(getCalendarVisibleHeading(calendar)).toContain("2021");
 
         // a few months ahead
         calendar.focusedDate = "2021-05-01";
         await nextFrame();
-        await expect.element(getMonthHeading(first)).toHaveTextContent("April");
-        await expect.element(getMonthHeading(second)).toHaveTextContent("May");
-        await expect.element(getCalendarVisibleHeading(calendar)).toHaveTextContent("2021");
+        await expect.poll(getMonthHeading(first)).toContain("April");
+        await expect.poll(getMonthHeading(second)).toContain("May");
+        await expect.poll(getCalendarVisibleHeading(calendar)).toContain("2021");
 
         // a few months back
         calendar.focusedDate = "2020-12-01";
         await nextFrame();
-        await expect.element(getMonthHeading(first)).toHaveTextContent("December");
-        await expect.element(getMonthHeading(second)).toHaveTextContent("January");
-        await expect.element(getCalendarVisibleHeading(calendar)).toHaveTextContent(/2020/);
-        await expect.element(getCalendarVisibleHeading(calendar)).toHaveTextContent(/2021/);
+        await expect.poll(getMonthHeading(first)).toContain("December");
+        await expect.poll(getMonthHeading(second)).toContain("January");
+        await expect.poll(getCalendarVisibleHeading(calendar)).toMatch(/2020/);
+        await expect.poll(getCalendarVisibleHeading(calendar)).toMatch(/2021/);
       });
     });
   });
@@ -711,8 +703,8 @@ describe("CalendarDate", () => {
       );
 
       const [first, second] = getMonths(calendar);
-      await expect.element(getMonthHeading(first!)).toHaveTextContent("January");
-      await expect.element(getMonthHeading(second!)).toHaveTextContent("February");
+      await expect.poll(getMonthHeading(first!)).toContain("January");
+      await expect.poll(getMonthHeading(second!)).toContain("February");
     });
 
     it("respects `months` when paginating", async () => {
@@ -726,12 +718,12 @@ describe("CalendarDate", () => {
       const [first, second] = getMonths(calendar);
 
       await getNextPageButton(calendar).click();
-      await expect.element(getMonthHeading(first!)).toHaveTextContent("March");
-      await expect.element(getMonthHeading(second!)).toHaveTextContent("April");
+      await expect.poll(getMonthHeading(first!)).toContain("March");
+      await expect.poll(getMonthHeading(second!)).toContain("April");
 
       await getPrevPageButton(calendar).click();
-      await expect.element(getMonthHeading(first!)).toHaveTextContent("January");
-      await expect.element(getMonthHeading(second!)).toHaveTextContent("February");
+      await expect.poll(getMonthHeading(first!)).toContain("January");
+      await expect.poll(getMonthHeading(second!)).toContain("February");
     });
   });
 
@@ -748,7 +740,7 @@ describe("CalendarDate", () => {
       const month = getMonth(calendar);
 
       const heading = getMonthHeading(month);
-      await expect.element(heading).toHaveTextContent(
+      await expect.poll(heading).toContain(
         todaysDate.toLocaleDateString("en-GB", { month: "long", timeZone: "UTC" })
       );
 
@@ -799,40 +791,40 @@ describe("CalendarDate", () => {
         <Fixture value="2020-01-01" locale="de-DE" />
       );
 
-      await expect.element(getCalendarHeading(calendar)).toHaveTextContent("Januar 2020");
+      await expect.poll(getCalendarHeading(calendar)).toContain("Januar 2020");
 
       await getNextPageButton(calendar).click();
-      await expect.element(getCalendarHeading(calendar)).toHaveTextContent("Februar 2020");
+      await expect.poll(getCalendarHeading(calendar)).toContain("Februar 2020");
 
       await getNextPageButton(calendar).click();
-      await expect.element(getCalendarHeading(calendar)).toHaveTextContent("März 2020");
+      await expect.poll(getCalendarHeading(calendar)).toContain("März 2020");
 
       await getNextPageButton(calendar).click();
-      await expect.element(getCalendarHeading(calendar)).toHaveTextContent("April 2020");
+      await expect.poll(getCalendarHeading(calendar)).toContain("April 2020");
 
       await getNextPageButton(calendar).click();
-      await expect.element(getCalendarHeading(calendar)).toHaveTextContent("Mai 2020");
+      await expect.poll(getCalendarHeading(calendar)).toContain("Mai 2020");
 
       await getNextPageButton(calendar).click();
-      await expect.element(getCalendarHeading(calendar)).toHaveTextContent("Juni 2020");
+      await expect.poll(getCalendarHeading(calendar)).toContain("Juni 2020");
 
       await getNextPageButton(calendar).click();
-      await expect.element(getCalendarHeading(calendar)).toHaveTextContent("Juli 2020");
+      await expect.poll(getCalendarHeading(calendar)).toContain("Juli 2020");
 
       await getNextPageButton(calendar).click();
-      await expect.element(getCalendarHeading(calendar)).toHaveTextContent("August 2020");
+      await expect.poll(getCalendarHeading(calendar)).toContain("August 2020");
 
       await getNextPageButton(calendar).click();
-      await expect.element(getCalendarHeading(calendar)).toHaveTextContent("September 2020");
+      await expect.poll(getCalendarHeading(calendar)).toContain("September 2020");
 
       await getNextPageButton(calendar).click();
-      await expect.element(getCalendarHeading(calendar)).toHaveTextContent("Oktober 2020");
+      await expect.poll(getCalendarHeading(calendar)).toContain("Oktober 2020");
 
       await getNextPageButton(calendar).click();
-      await expect.element(getCalendarHeading(calendar)).toHaveTextContent("November 2020");
+      await expect.poll(getCalendarHeading(calendar)).toContain("November 2020");
 
       await getNextPageButton(calendar).click();
-      await expect.element(getCalendarHeading(calendar)).toHaveTextContent("Dezember 2020");
+      await expect.poll(getCalendarHeading(calendar)).toContain("Dezember 2020");
     });
   });
 
@@ -853,7 +845,7 @@ describe("CalendarDate", () => {
       const month = getMonth(calendar);
       const firstJan = getDayButton(month, "1 January");
 
-      await expect.element(getMonthHeading(month)).toHaveTextContent("January");
+      await expect.poll(getMonthHeading(month)).toContain("January");
       await expect.element(page.elementLocator(firstJan)).toHaveAttribute("aria-pressed", "true");
     });
   });

--- a/src/calendar-date/calendar-date.test.tsx
+++ b/src/calendar-date/calendar-date.test.tsx
@@ -23,7 +23,9 @@ import { PlainDate, PlainYearMonth } from "../utils/temporal.js";
 import { getToday, toDate } from "../utils/date.js";
 
 async function nextFrame() {
-  return new Promise((resolve) => requestAnimationFrame(() => resolve(undefined)));
+  return new Promise((resolve) =>
+    requestAnimationFrame(() => resolve(undefined)),
+  );
 }
 
 type TestProps = {
@@ -59,12 +61,16 @@ describe("CalendarDate", () => {
     describe("controls", () => {
       it("has a label for next page button", async () => {
         const calendar = await mount(<Fixture />);
-        await expect.element(getNextPageButton(calendar)).toHaveTextContent("Next");
+        await expect
+          .element(getNextPageButton(calendar))
+          .toHaveTextContent("Next");
       });
 
       it("has a label for previous page button", async () => {
         const calendar = await mount(<Fixture />);
-        await expect.element(getPrevPageButton(calendar)).toHaveTextContent("Previous");
+        await expect
+          .element(getPrevPageButton(calendar))
+          .toHaveTextContent("Previous");
       });
     });
 
@@ -81,7 +87,7 @@ describe("CalendarDate", () => {
       });
 
       const heading = getCalendarHeading(calendar);
-      await expect.poll(heading).toContain(formatter.format(yearMonth));
+      expect(heading).toEqual(formatter.format(yearMonth));
     });
 
     it("correctly labels a range of months", async () => {
@@ -89,7 +95,7 @@ describe("CalendarDate", () => {
         <Fixture months={2} value="2023-12-01">
           <CalendarMonth />
           <CalendarMonth offset={1} />
-        </Fixture>
+        </Fixture>,
       );
 
       const start = new PlainYearMonth(2023, 12);
@@ -100,7 +106,9 @@ describe("CalendarDate", () => {
         timeZone: "UTC",
       });
 
-      await expect.poll(getCalendarHeading(calendar)).toBe(formatter.formatRange(toDate(start), toDate(end)));
+      expect(getCalendarHeading(calendar)).toEqual(
+        formatter.formatRange(toDate(start), toDate(end)),
+      );
     });
   });
 
@@ -108,7 +116,7 @@ describe("CalendarDate", () => {
     it("can select a date in the future", async () => {
       const spy = createSpy();
       const calendar = await mount(
-        <Fixture value="2020-01-01" onchange={spy} />
+        <Fixture value="2020-01-01" onchange={spy} />,
       );
       const month = getMonth(calendar);
       const nextMonth = getNextPageButton(calendar);
@@ -125,7 +133,7 @@ describe("CalendarDate", () => {
     it("can select a date in the past", async () => {
       const spy = createSpy();
       const calendar = await mount(
-        <Fixture value="2020-01-01" onchange={spy} />
+        <Fixture value="2020-01-01" onchange={spy} />,
       );
       const month = getMonth(calendar);
 
@@ -197,7 +205,7 @@ describe("CalendarDate", () => {
     it("supports navigating to disabled dates", async () => {
       const spy = createSpy();
       const calendar = await mount(
-        <Fixture value="2020-01-01" onchange={spy} />
+        <Fixture value="2020-01-01" onchange={spy} />,
       );
 
       // disable weekends
@@ -250,7 +258,7 @@ describe("CalendarDate", () => {
           <Fixture value="2020-01-01" months={2}>
             <CalendarMonth />
             <CalendarMonth offset={1} />
-          </Fixture>
+          </Fixture>,
         );
         const [first, second] = getMonths(calendar) as [
           MonthInstance,
@@ -258,8 +266,8 @@ describe("CalendarDate", () => {
         ];
 
         await getNextPageButton(calendar).click();
-        await expect.poll(getMonthHeading(first!)).toContain("March");
-        await expect.poll(getMonthHeading(second!)).toContain("April");
+        expect(getMonthHeading(first!)).toEqual("March");
+        expect(getMonthHeading(second!)).toEqual("April");
       });
 
       it("updates page as user navigates dates", async () => {
@@ -267,7 +275,7 @@ describe("CalendarDate", () => {
           <Fixture value="2020-01-01" months={2}>
             <CalendarMonth />
             <CalendarMonth offset={1} />
-          </Fixture>
+          </Fixture>,
         );
         const [first, second] = getMonths(calendar) as [
           MonthInstance,
@@ -281,53 +289,53 @@ describe("CalendarDate", () => {
 
         // move to feb, within page
         await userEvent.keyboard("{PageDown}");
-        await expect.poll(getMonthHeading(first)).toContain("January");
-        await expect.poll(getMonthHeading(second)).toContain("February");
+        expect(getMonthHeading(first)).toEqual("January");
+        expect(getMonthHeading(second)).toEqual("February");
 
         // move to march, out of page
         await userEvent.keyboard("{PageDown}");
-        await expect.poll(getMonthHeading(first)).toContain("March");
-        await expect.poll(getMonthHeading(second)).toContain("April");
+        expect(getMonthHeading(first)).toEqual("March");
+        expect(getMonthHeading(second)).toEqual("April");
 
         // move to april, should be on same page
         await userEvent.keyboard("{PageDown}");
-        await expect.poll(getMonthHeading(first)).toContain("March");
-        await expect.poll(getMonthHeading(second)).toContain("April");
+        expect(getMonthHeading(first)).toEqual("March");
+        expect(getMonthHeading(second)).toEqual("April");
 
         // move to march, within page
         await userEvent.keyboard("{PageUp}");
-        await expect.poll(getMonthHeading(first)).toContain("March");
-        await expect.poll(getMonthHeading(second)).toContain("April");
+        expect(getMonthHeading(first)).toEqual("March");
+        expect(getMonthHeading(second)).toEqual("April");
 
         // move to feb, out of page
         await userEvent.keyboard("{PageUp}");
-        await expect.poll(getMonthHeading(first)).toContain("January");
-        await expect.poll(getMonthHeading(second)).toContain("February");
+        expect(getMonthHeading(first)).toEqual("January");
+        expect(getMonthHeading(second)).toEqual("February");
 
         // move to jan, within page
         await userEvent.keyboard("{PageUp}");
-        await expect.poll(getMonthHeading(first)).toContain("January");
-        await expect.poll(getMonthHeading(second)).toContain("February");
+        expect(getMonthHeading(first)).toEqual("January");
+        expect(getMonthHeading(second)).toEqual("February");
 
         // move to dec, out of page
         await userEvent.keyboard("{PageUp}");
-        await expect.poll(getMonthHeading(first)).toContain("November");
-        await expect.poll(getMonthHeading(second)).toContain("December");
+        expect(getMonthHeading(first)).toEqual("November");
+        expect(getMonthHeading(second)).toEqual("December");
 
         // sanity check
         expect(calendar.focusedDate).toBe("2019-12-01");
 
         // move one year ahead
         await sendShiftPress("PageDown");
-        await expect.poll(getCalendarVisibleHeading(calendar)).toContain("2020");
-        await expect.poll(getMonthHeading(first)).toContain("November");
-        await expect.poll(getMonthHeading(second)).toContain("December");
+        expect(getCalendarVisibleHeading(calendar)).toEqual("2020");
+        expect(getMonthHeading(first)).toEqual("November");
+        expect(getMonthHeading(second)).toEqual("December");
 
         // move one year back
         await sendShiftPress("PageUp");
-        await expect.poll(getCalendarVisibleHeading(calendar)).toContain("2019");
-        await expect.poll(getMonthHeading(first)).toContain("November");
-        await expect.poll(getMonthHeading(second)).toContain("December");
+        expect(getCalendarVisibleHeading(calendar)).toEqual("2019");
+        expect(getMonthHeading(first)).toEqual("November");
+        expect(getMonthHeading(second)).toEqual("December");
       });
 
       it("pages by number of months", async () => {
@@ -335,7 +343,7 @@ describe("CalendarDate", () => {
           <Fixture value="2020-01-01" months={2}>
             <CalendarMonth />
             <CalendarMonth offset={1} />
-          </Fixture>
+          </Fixture>,
         );
 
         const next = getNextPageButton(calendar);
@@ -346,24 +354,24 @@ describe("CalendarDate", () => {
         ];
 
         await next.click();
-        await expect.poll(getMonthHeading(first)).toContain("March");
-        await expect.poll(getMonthHeading(second)).toContain("April");
+        expect(getMonthHeading(first)).toEqual("March");
+        expect(getMonthHeading(second)).toEqual("April");
 
         await next.click();
-        await expect.poll(getMonthHeading(first)).toContain("May");
-        await expect.poll(getMonthHeading(second)).toContain("June");
+        expect(getMonthHeading(first)).toEqual("May");
+        expect(getMonthHeading(second)).toEqual("June");
 
         await prev.click();
-        await expect.poll(getMonthHeading(first)).toContain("March");
-        await expect.poll(getMonthHeading(second)).toContain("April");
+        expect(getMonthHeading(first)).toEqual("March");
+        expect(getMonthHeading(second)).toEqual("April");
 
         await prev.click();
-        await expect.poll(getMonthHeading(first)).toContain("January");
-        await expect.poll(getMonthHeading(second)).toContain("February");
+        expect(getMonthHeading(first)).toEqual("January");
+        expect(getMonthHeading(second)).toEqual("February");
 
         await prev.click();
-        await expect.poll(getMonthHeading(first)).toContain("November");
-        await expect.poll(getMonthHeading(second)).toContain("December");
+        expect(getMonthHeading(first)).toEqual("November");
+        expect(getMonthHeading(second)).toEqual("December");
       });
 
       it("handles focused date prop changing", async () => {
@@ -371,7 +379,7 @@ describe("CalendarDate", () => {
           <Fixture value="2020-01-01" months={2}>
             <CalendarMonth />
             <CalendarMonth offset={1} />
-          </Fixture>
+          </Fixture>,
         );
         const [first, second] = getMonths(calendar) as [
           MonthInstance,
@@ -381,30 +389,30 @@ describe("CalendarDate", () => {
         // one year ahead
         calendar.focusedDate = "2021-01-01";
         await nextFrame();
-        await expect.poll(getMonthHeading(first)).toContain("January");
-        await expect.poll(getMonthHeading(second)).toContain("February");
-        await expect.poll(getCalendarVisibleHeading(calendar)).toContain("2021");
+        expect(getMonthHeading(first)).toEqual("January");
+        expect(getMonthHeading(second)).toEqual("February");
+        expect(getCalendarVisibleHeading(calendar)).toEqual("2021");
 
         // one month outside of page
         calendar.focusedDate = "2021-03-01";
         await nextFrame();
-        await expect.poll(getMonthHeading(first)).toContain("March");
-        await expect.poll(getMonthHeading(second)).toContain("April");
-        await expect.poll(getCalendarVisibleHeading(calendar)).toContain("2021");
+        expect(getMonthHeading(first)).toEqual("March");
+        expect(getMonthHeading(second)).toEqual("April");
+        expect(getCalendarVisibleHeading(calendar)).toEqual("2021");
 
         // a few months ahead
         calendar.focusedDate = "2021-05-01";
         await nextFrame();
-        await expect.poll(getMonthHeading(first)).toContain("May");
-        await expect.poll(getMonthHeading(second)).toContain("June");
-        await expect.poll(getCalendarVisibleHeading(calendar)).toContain("2021");
+        expect(getMonthHeading(first)).toEqual("May");
+        expect(getMonthHeading(second)).toEqual("June");
+        expect(getCalendarVisibleHeading(calendar)).toEqual("2021");
 
         // a few months back
         calendar.focusedDate = "2020-12-01";
         await nextFrame();
-        await expect.poll(getMonthHeading(first)).toContain("November");
-        await expect.poll(getMonthHeading(second)).toContain("December");
-        await expect.poll(getCalendarVisibleHeading(calendar)).toContain("2020");
+        expect(getMonthHeading(first)).toEqual("November");
+        expect(getMonthHeading(second)).toEqual("December");
+        expect(getCalendarVisibleHeading(calendar)).toEqual("2020");
       });
     });
 
@@ -414,7 +422,7 @@ describe("CalendarDate", () => {
           <Fixture value="2020-01-01" months={2} pageBy="single">
             <CalendarMonth />
             <CalendarMonth offset={1} />
-          </Fixture>
+          </Fixture>,
         );
 
         const [first, second] = getMonths(calendar) as [
@@ -429,55 +437,55 @@ describe("CalendarDate", () => {
 
         // move to feb, within page
         await userEvent.keyboard("{PageDown}");
-        await expect.poll(getMonthHeading(first)).toContain("January");
-        await expect.poll(getMonthHeading(second)).toContain("February");
+        expect(getMonthHeading(first)).toEqual("January");
+        expect(getMonthHeading(second)).toEqual("February");
 
         // move to march, out of page
         await userEvent.keyboard("{PageDown}");
-        await expect.poll(getMonthHeading(first)).toContain("February");
-        await expect.poll(getMonthHeading(second)).toContain("March");
+        expect(getMonthHeading(first)).toEqual("February");
+        expect(getMonthHeading(second)).toEqual("March");
 
         // move to april, should be on same page
         await userEvent.keyboard("{PageDown}");
-        await expect.poll(getMonthHeading(first)).toContain("March");
-        await expect.poll(getMonthHeading(second)).toContain("April");
+        expect(getMonthHeading(first)).toEqual("March");
+        expect(getMonthHeading(second)).toEqual("April");
 
         // move to march, within page
         await userEvent.keyboard("{PageUp}");
-        await expect.poll(getMonthHeading(first)).toContain("March");
-        await expect.poll(getMonthHeading(second)).toContain("April");
+        expect(getMonthHeading(first)).toEqual("March");
+        expect(getMonthHeading(second)).toEqual("April");
 
         // move to feb, out of page
         await userEvent.keyboard("{PageUp}");
-        await expect.poll(getMonthHeading(first)).toContain("February");
-        await expect.poll(getMonthHeading(second)).toContain("March");
+        expect(getMonthHeading(first)).toEqual("February");
+        expect(getMonthHeading(second)).toEqual("March");
 
         // move to jan, within page
         await userEvent.keyboard("{PageUp}");
-        await expect.poll(getMonthHeading(first)).toContain("January");
-        await expect.poll(getMonthHeading(second)).toContain("February");
+        expect(getMonthHeading(first)).toEqual("January");
+        expect(getMonthHeading(second)).toEqual("February");
 
         // move to dec, out of page
         await userEvent.keyboard("{PageUp}");
-        await expect.poll(getMonthHeading(first)).toContain("December");
-        await expect.poll(getMonthHeading(second)).toContain("January");
+        expect(getMonthHeading(first)).toEqual("December");
+        expect(getMonthHeading(second)).toEqual("January");
 
         // sanity check
         expect(calendar.focusedDate).toBe("2019-12-01");
 
         // move one year ahead
         await sendShiftPress("PageDown");
-        await expect.poll(getCalendarVisibleHeading(calendar)).toMatch(/2020/);
-        await expect.poll(getCalendarVisibleHeading(calendar)).toMatch(/2021/);
-        await expect.poll(getMonthHeading(first)).toContain("December");
-        await expect.poll(getMonthHeading(second)).toContain("January");
+        expect(getCalendarVisibleHeading(calendar)).toMatch(/2020/);
+        expect(getCalendarVisibleHeading(calendar)).toMatch(/2021/);
+        expect(getMonthHeading(first)).toEqual("December");
+        expect(getMonthHeading(second)).toEqual("January");
 
         // move one year back
         await sendShiftPress("PageUp");
-        await expect.poll(getMonthHeading(first)).toContain("December");
-        await expect.poll(getCalendarVisibleHeading(calendar)).toMatch(/2019/);
-        await expect.poll(getCalendarVisibleHeading(calendar)).toMatch(/2020/);
-        await expect.poll(getMonthHeading(second)).toContain("January");
+        expect(getMonthHeading(first)).toEqual("December");
+        expect(getCalendarVisibleHeading(calendar)).toMatch(/2019/);
+        expect(getCalendarVisibleHeading(calendar)).toMatch(/2020/);
+        expect(getMonthHeading(second)).toEqual("January");
       });
 
       it("pages by single month", async () => {
@@ -485,7 +493,7 @@ describe("CalendarDate", () => {
           <Fixture value="2020-01-01" months={2} pageBy="single">
             <CalendarMonth />
             <CalendarMonth offset={1} />
-          </Fixture>
+          </Fixture>,
         );
         const [first, second] = getMonths(calendar) as [
           MonthInstance,
@@ -496,24 +504,24 @@ describe("CalendarDate", () => {
         const prev = getPrevPageButton(calendar);
 
         await next.click();
-        await expect.poll(getMonthHeading(first)).toContain("February");
-        await expect.poll(getMonthHeading(second)).toContain("March");
+        expect(getMonthHeading(first)).toEqual("February");
+        expect(getMonthHeading(second)).toEqual("March");
 
         await next.click();
-        await expect.poll(getMonthHeading(first)).toContain("March");
-        await expect.poll(getMonthHeading(second)).toContain("April");
+        expect(getMonthHeading(first)).toEqual("March");
+        expect(getMonthHeading(second)).toEqual("April");
 
         await prev.click();
-        await expect.poll(getMonthHeading(first)).toContain("February");
-        await expect.poll(getMonthHeading(second)).toContain("March");
+        expect(getMonthHeading(first)).toEqual("February");
+        expect(getMonthHeading(second)).toEqual("March");
 
         await prev.click();
-        await expect.poll(getMonthHeading(first)).toContain("January");
-        await expect.poll(getMonthHeading(second)).toContain("February");
+        expect(getMonthHeading(first)).toEqual("January");
+        expect(getMonthHeading(second)).toEqual("February");
 
         await prev.click();
-        await expect.poll(getMonthHeading(first)).toContain("December");
-        await expect.poll(getMonthHeading(second)).toContain("January");
+        expect(getMonthHeading(first)).toEqual("December");
+        expect(getMonthHeading(second)).toEqual("January");
       });
 
       it("pages by single month with 12 months", async () => {
@@ -531,7 +539,7 @@ describe("CalendarDate", () => {
             <CalendarMonth offset={9} />
             <CalendarMonth offset={10} />
             <CalendarMonth offset={11} />
-          </Fixture>
+          </Fixture>,
         );
         const months = getMonths(calendar);
         const first = months[0] as MonthInstance;
@@ -539,23 +547,23 @@ describe("CalendarDate", () => {
 
         // with page-by="single", 12 months starting from June
         // should show Jun-May, not snap to Jan-Dec
-        await expect.poll(getMonthHeading(first)).toContain("June");
-        await expect.poll(getMonthHeading(last)).toContain("May");
+        expect(getMonthHeading(first)).toEqual("June");
+        expect(getMonthHeading(last)).toEqual("May");
 
         const next = getNextPageButton(calendar);
         const prev = getPrevPageButton(calendar);
 
         await next.click();
-        await expect.poll(getMonthHeading(first)).toContain("July");
-        await expect.poll(getMonthHeading(last)).toContain("June");
+        expect(getMonthHeading(first)).toEqual("July");
+        expect(getMonthHeading(last)).toEqual("June");
 
         await prev.click();
-        await expect.poll(getMonthHeading(first)).toContain("June");
-        await expect.poll(getMonthHeading(last)).toContain("May");
+        expect(getMonthHeading(first)).toEqual("June");
+        expect(getMonthHeading(last)).toEqual("May");
 
         await prev.click();
-        await expect.poll(getMonthHeading(first)).toContain("May");
-        await expect.poll(getMonthHeading(last)).toContain("April");
+        expect(getMonthHeading(first)).toEqual("May");
+        expect(getMonthHeading(last)).toEqual("April");
       });
 
       it("handles focused date prop changing", async () => {
@@ -563,7 +571,7 @@ describe("CalendarDate", () => {
           <Fixture value="2020-01-01" months={2} pageBy="single">
             <CalendarMonth />
             <CalendarMonth offset={1} />
-          </Fixture>
+          </Fixture>,
         );
         const [first, second] = getMonths(calendar) as [
           MonthInstance,
@@ -573,31 +581,31 @@ describe("CalendarDate", () => {
         // one year ahead
         calendar.focusedDate = "2021-01-01";
         await nextFrame();
-        await expect.poll(getMonthHeading(first)).toContain("January");
-        await expect.poll(getMonthHeading(second)).toContain("February");
-        await expect.poll(getCalendarVisibleHeading(calendar)).toContain("2021");
+        expect(getMonthHeading(first)).toEqual("January");
+        expect(getMonthHeading(second)).toEqual("February");
+        expect(getCalendarVisibleHeading(calendar)).toEqual("2021");
 
         // one month outside of page
         calendar.focusedDate = "2021-03-01";
         await nextFrame();
-        await expect.poll(getMonthHeading(first)).toContain("February");
-        await expect.poll(getMonthHeading(second)).toContain("March");
-        await expect.poll(getCalendarVisibleHeading(calendar)).toContain("2021");
+        expect(getMonthHeading(first)).toEqual("February");
+        expect(getMonthHeading(second)).toEqual("March");
+        expect(getCalendarVisibleHeading(calendar)).toEqual("2021");
 
         // a few months ahead
         calendar.focusedDate = "2021-05-01";
         await nextFrame();
-        await expect.poll(getMonthHeading(first)).toContain("April");
-        await expect.poll(getMonthHeading(second)).toContain("May");
-        await expect.poll(getCalendarVisibleHeading(calendar)).toContain("2021");
+        expect(getMonthHeading(first)).toEqual("April");
+        expect(getMonthHeading(second)).toEqual("May");
+        expect(getCalendarVisibleHeading(calendar)).toEqual("2021");
 
         // a few months back
         calendar.focusedDate = "2020-12-01";
         await nextFrame();
-        await expect.poll(getMonthHeading(first)).toContain("December");
-        await expect.poll(getMonthHeading(second)).toContain("January");
-        await expect.poll(getCalendarVisibleHeading(calendar)).toMatch(/2020/);
-        await expect.poll(getCalendarVisibleHeading(calendar)).toMatch(/2021/);
+        expect(getMonthHeading(first)).toEqual("December");
+        expect(getMonthHeading(second)).toEqual("January");
+        expect(getCalendarVisibleHeading(calendar)).toMatch(/2020/);
+        expect(getCalendarVisibleHeading(calendar)).toMatch(/2021/);
       });
     });
   });
@@ -606,7 +614,7 @@ describe("CalendarDate", () => {
     it("raises a focusday event", async () => {
       const spy = createSpy<(e: CustomEvent<Date>) => void>();
       const calendar = await mount(
-        <Fixture value="2022-01-01" onfocusday={spy} />
+        <Fixture value="2022-01-01" onfocusday={spy} />,
       );
 
       // click next button
@@ -619,7 +627,7 @@ describe("CalendarDate", () => {
     it("raises a change event", async () => {
       const spy = createSpy<(e: Event) => void>();
       const calendar = await mount(
-        <Fixture value="2022-01-01" onchange={spy} />
+        <Fixture value="2022-01-01" onchange={spy} />,
       );
       const month = getMonth(calendar);
 
@@ -637,7 +645,7 @@ describe("CalendarDate", () => {
       const calendar = await mount(
         <Fixture value="2020-01-01">
           <CalendarMonth />
-        </Fixture>
+        </Fixture>,
       );
 
       // tab to next page, click
@@ -645,9 +653,10 @@ describe("CalendarDate", () => {
       await userEvent.keyboard("{Tab}");
       await userEvent.keyboard("{Enter}");
 
-      const nextButton = calendar.shadowRoot!.querySelector<HTMLButtonElement>(
-        `button[part~="next"]`
-      )!;
+      const nextButton =
+        calendar.shadowRoot!.querySelector<HTMLButtonElement>(
+          `button[part~="next"]`,
+        )!;
       expect(nextButton).toBeActiveElement();
     });
 
@@ -656,7 +665,7 @@ describe("CalendarDate", () => {
       const calendar = await mount(
         <Fixture value="2020-01-01" onchange={spy} showOutsideDays>
           <CalendarMonth />
-        </Fixture>
+        </Fixture>,
       );
       const month = getMonth(calendar);
 
@@ -676,20 +685,24 @@ describe("CalendarDate", () => {
   describe("min/max support", () => {
     it("disables prev month button if same month and year as min", async () => {
       const calendar = await mount(
-        <Fixture value="2020-04-19" min="2020-04-01" />
+        <Fixture value="2020-04-19" min="2020-04-01" />,
       );
 
       const prevMonthButton = getPrevPageButton(calendar);
-      await expect.element(prevMonthButton).toHaveAttribute("aria-disabled", "true");
+      await expect
+        .element(prevMonthButton)
+        .toHaveAttribute("aria-disabled", "true");
     });
 
     it("disables next month button if same month and year as max", async () => {
       const calendar = await mount(
-        <Fixture value="2020-04-19" max="2020-04-30" />
+        <Fixture value="2020-04-19" max="2020-04-30" />,
       );
 
       const nextMonthButton = getNextPageButton(calendar);
-      await expect.element(nextMonthButton).toHaveAttribute("aria-disabled", "true");
+      await expect
+        .element(nextMonthButton)
+        .toHaveAttribute("aria-disabled", "true");
     });
   });
 
@@ -699,12 +712,12 @@ describe("CalendarDate", () => {
         <Fixture value="2020-01-01" months={2}>
           <CalendarMonth />
           <CalendarMonth offset={1} />
-        </Fixture>
+        </Fixture>,
       );
 
       const [first, second] = getMonths(calendar);
-      await expect.poll(getMonthHeading(first!)).toContain("January");
-      await expect.poll(getMonthHeading(second!)).toContain("February");
+      expect(getMonthHeading(first!)).toEqual("January");
+      expect(getMonthHeading(second!)).toEqual("February");
     });
 
     it("respects `months` when paginating", async () => {
@@ -712,18 +725,18 @@ describe("CalendarDate", () => {
         <Fixture value="2020-01-01" months={2}>
           <CalendarMonth />
           <CalendarMonth offset={1} />
-        </Fixture>
+        </Fixture>,
       );
 
       const [first, second] = getMonths(calendar);
 
       await getNextPageButton(calendar).click();
-      await expect.poll(getMonthHeading(first!)).toContain("March");
-      await expect.poll(getMonthHeading(second!)).toContain("April");
+      expect(getMonthHeading(first!)).toEqual("March");
+      expect(getMonthHeading(second!)).toEqual("April");
 
       await getPrevPageButton(calendar).click();
-      await expect.poll(getMonthHeading(first!)).toContain("January");
-      await expect.poll(getMonthHeading(second!)).toContain("February");
+      expect(getMonthHeading(first!)).toEqual("January");
+      expect(getMonthHeading(second!)).toEqual("February");
     });
   });
 
@@ -731,7 +744,9 @@ describe("CalendarDate", () => {
     it("defaults to `value` if not set", async () => {
       const calendar = await mount(<Fixture value="2020-01-01" />);
       const day = getDayButton(getMonth(calendar), "1 January");
-      await expect.element(page.elementLocator(day)).toHaveAttribute("tabindex", "0");
+      await expect
+        .element(page.elementLocator(day))
+        .toHaveAttribute("tabindex", "0");
     });
 
     it("defaults to today if no value set", async () => {
@@ -739,9 +754,11 @@ describe("CalendarDate", () => {
       const todaysDate = toDate(getToday());
       const month = getMonth(calendar);
 
-      const heading = getMonthHeading(month);
-      await expect.poll(heading).toContain(
-        todaysDate.toLocaleDateString("en-GB", { month: "long", timeZone: "UTC" })
+      expect(getMonthHeading(month)).toEqual(
+        todaysDate.toLocaleDateString("en-GB", {
+          month: "long",
+          timeZone: "UTC",
+        }),
       );
 
       const button = getDayButton(
@@ -750,37 +767,45 @@ describe("CalendarDate", () => {
           month: "long",
           day: "numeric",
           timeZone: "UTC",
-        })
+        }),
       );
-      await expect.element(page.elementLocator(button)).toHaveAttribute("tabindex", "0");
+      await expect
+        .element(page.elementLocator(button))
+        .toHaveAttribute("tabindex", "0");
     });
 
     it("can be changed via props", async () => {
       const calendar = await mount(
-        <Fixture value="2020-01-01" focusedDate="2020-02-15" />
+        <Fixture value="2020-01-01" focusedDate="2020-02-15" />,
       );
       const month = getMonth(calendar);
 
       const day = getDayButton(month, "15 February");
-      await expect.element(page.elementLocator(day)).toHaveAttribute("tabindex", "0");
+      await expect
+        .element(page.elementLocator(day))
+        .toHaveAttribute("tabindex", "0");
 
       calendar.focusedDate = "2020-04-15";
       await nextFrame();
 
       const newDay = getDayButton(month, "15 April");
-      await expect.element(page.elementLocator(newDay)).toHaveAttribute("tabindex", "0");
+      await expect
+        .element(page.elementLocator(newDay))
+        .toHaveAttribute("tabindex", "0");
     });
 
     it("updates as user navigates", async () => {
       const calendar = await mount(
-        <Fixture value="2020-01-01" focusedDate="2020-02-15" />
+        <Fixture value="2020-01-01" focusedDate="2020-02-15" />,
       );
       const month = getMonth(calendar);
 
       await getPrevPageButton(calendar).click();
 
       const day = getDayButton(month, "15 January");
-      await expect.element(page.elementLocator(day)).toHaveAttribute("tabindex", "0");
+      await expect
+        .element(page.elementLocator(day))
+        .toHaveAttribute("tabindex", "0");
       expect(calendar.focusedDate).toBe("2020-01-15");
     });
   });
@@ -788,43 +813,43 @@ describe("CalendarDate", () => {
   describe("localization", () => {
     it("localizes heading", async () => {
       const calendar = await mount(
-        <Fixture value="2020-01-01" locale="de-DE" />
+        <Fixture value="2020-01-01" locale="de-DE" />,
       );
 
-      await expect.poll(getCalendarHeading(calendar)).toContain("Januar 2020");
+      expect(getCalendarHeading(calendar)).toEqual("Januar 2020");
 
       await getNextPageButton(calendar).click();
-      await expect.poll(getCalendarHeading(calendar)).toContain("Februar 2020");
+      expect(getCalendarHeading(calendar)).toEqual("Februar 2020");
 
       await getNextPageButton(calendar).click();
-      await expect.poll(getCalendarHeading(calendar)).toContain("März 2020");
+      expect(getCalendarHeading(calendar)).toEqual("März 2020");
 
       await getNextPageButton(calendar).click();
-      await expect.poll(getCalendarHeading(calendar)).toContain("April 2020");
+      expect(getCalendarHeading(calendar)).toEqual("April 2020");
 
       await getNextPageButton(calendar).click();
-      await expect.poll(getCalendarHeading(calendar)).toContain("Mai 2020");
+      expect(getCalendarHeading(calendar)).toEqual("Mai 2020");
 
       await getNextPageButton(calendar).click();
-      await expect.poll(getCalendarHeading(calendar)).toContain("Juni 2020");
+      expect(getCalendarHeading(calendar)).toEqual("Juni 2020");
 
       await getNextPageButton(calendar).click();
-      await expect.poll(getCalendarHeading(calendar)).toContain("Juli 2020");
+      expect(getCalendarHeading(calendar)).toEqual("Juli 2020");
 
       await getNextPageButton(calendar).click();
-      await expect.poll(getCalendarHeading(calendar)).toContain("August 2020");
+      expect(getCalendarHeading(calendar)).toEqual("August 2020");
 
       await getNextPageButton(calendar).click();
-      await expect.poll(getCalendarHeading(calendar)).toContain("September 2020");
+      expect(getCalendarHeading(calendar)).toEqual("September 2020");
 
       await getNextPageButton(calendar).click();
-      await expect.poll(getCalendarHeading(calendar)).toContain("Oktober 2020");
+      expect(getCalendarHeading(calendar)).toEqual("Oktober 2020");
 
       await getNextPageButton(calendar).click();
-      await expect.poll(getCalendarHeading(calendar)).toContain("November 2020");
+      expect(getCalendarHeading(calendar)).toEqual("November 2020");
 
       await getNextPageButton(calendar).click();
-      await expect.poll(getCalendarHeading(calendar)).toContain("Dezember 2020");
+      expect(getCalendarHeading(calendar)).toEqual("Dezember 2020");
     });
   });
 
@@ -839,14 +864,16 @@ describe("CalendarDate", () => {
               </div>
             </div>
           </div>
-        </Fixture>
+        </Fixture>,
       );
 
       const month = getMonth(calendar);
       const firstJan = getDayButton(month, "1 January");
 
-      await expect.poll(getMonthHeading(month)).toContain("January");
-      await expect.element(page.elementLocator(firstJan)).toHaveAttribute("aria-pressed", "true");
+      expect(getMonthHeading(month)).toEqual("January");
+      await expect
+        .element(page.elementLocator(firstJan))
+        .toHaveAttribute("aria-pressed", "true");
     });
   });
 
@@ -855,11 +882,12 @@ describe("CalendarDate", () => {
       const calendar = await mount(<Fixture value="2020-01-01" />);
       const day = getDayButton(getMonth(calendar), "1 January");
       const prevButton = calendar.shadowRoot!.querySelector<HTMLButtonElement>(
-        `button[part~="previous"]`
+        `button[part~="previous"]`,
       )!;
-      const nextButton = calendar.shadowRoot!.querySelector<HTMLButtonElement>(
-        `button[part~="next"]`
-      )!;
+      const nextButton =
+        calendar.shadowRoot!.querySelector<HTMLButtonElement>(
+          `button[part~="next"]`,
+        )!;
 
       calendar.focus({ target: "previous" });
       expect(prevButton).toBeActiveElement(calendar.shadowRoot!);

--- a/src/calendar-heading/CalendarHeadingContext.ts
+++ b/src/calendar-heading/CalendarHeadingContext.ts
@@ -1,0 +1,25 @@
+import { createContext } from "atomico";
+import { PlainYearMonth } from "../utils/temporal.js";
+
+export interface HeadingRangeContext {
+  type: "range";
+  value: { start: PlainYearMonth; end: PlainYearMonth };
+  locale?: string;
+}
+
+export interface HeadingDateContext {
+  type: "date";
+  value: PlainYearMonth;
+  locale?: string;
+}
+
+export type HeadingContextValue = HeadingRangeContext | HeadingDateContext;
+
+const now = new Date();
+
+export const CalendarHeadingContext = createContext<HeadingContextValue>({
+  type: "date",
+  value: new PlainYearMonth(now.getUTCFullYear(), now.getUTCMonth() + 1),
+});
+
+customElements.define("calendar-heading-ctx", CalendarHeadingContext);

--- a/src/calendar-heading/calendar-heading.test.tsx
+++ b/src/calendar-heading/calendar-heading.test.tsx
@@ -1,0 +1,120 @@
+import { describe, it, expect } from "vitest";
+import type { VNodeAny } from "atomico/types/vnode";
+import { mount, getMonth, type CalendarInstance, type MonthInstance } from "../utils/test.js";
+import { CalendarMonth } from "../calendar-month/calendar-month.js";
+import { CalendarDate } from "../calendar-date/calendar-date.js";
+import { CalendarHeading } from "./calendar-heading.js";
+import { PlainYearMonth } from "../utils/temporal.js";
+import { toDate } from "../utils/date.js";
+
+function Fixture({ children, ...props }: Record<string, any>): VNodeAny {
+  return (
+    <CalendarDate locale="en-GB" {...props}>
+      {children ?? <CalendarMonth />}
+    </CalendarDate>
+  );
+}
+
+function getSlottedHeadingText(root: CalendarInstance | MonthInstance) {
+  const heading = root.querySelector<HTMLElement>("calendar-heading");
+
+  if (!heading) {
+    throw new Error("Could not find slotted calendar-heading");
+  }
+
+  return () => heading.shadowRoot?.textContent ?? heading.textContent ?? "";
+}
+
+describe("CalendarHeading", () => {
+  it("formats using the provided month and year options", async () => {
+    const calendar = await mount(
+      <Fixture value="2024-03-15">
+        <CalendarHeading slot="heading" month="short" year="2-digit" />
+        <CalendarMonth />
+      </Fixture>
+    );
+
+    const headingText = getSlottedHeadingText(calendar);
+    const formatter = new Intl.DateTimeFormat("en-GB", { timeZone: "UTC",
+      month: "short",
+      year: "2-digit",
+    });
+    const expected = formatter.format(toDate(new PlainYearMonth(2024, 3)));
+
+    await expect.poll(headingText).toBe(expected);
+  });
+
+  it("only includes options that are set", async () => {
+    const calendar = await mount(
+      <Fixture value="2024-09-01">
+        <CalendarHeading slot="heading" month="long" />
+        <CalendarMonth />
+      </Fixture>
+    );
+
+    const headingText = getSlottedHeadingText(calendar);
+    const formatter = new Intl.DateTimeFormat("en-GB", { timeZone: "UTC", month: "long" });
+    const expected = formatter.format(toDate(new PlainYearMonth(2024, 9)));
+
+    await expect.poll(headingText).toBe(expected);
+  });
+
+  it("formats a range when showing multiple months", async () => {
+    const calendar = await mount(
+      <Fixture months={2} value="2023-12-01">
+        <CalendarHeading slot="heading" month="long" year="numeric" />
+        <CalendarMonth />
+        <CalendarMonth offset={1} />
+      </Fixture>
+    );
+
+    const headingText = getSlottedHeadingText(calendar);
+    const start = toDate(new PlainYearMonth(2023, 12));
+    const end = toDate(new PlainYearMonth(2024, 1));
+    const formatter = new Intl.DateTimeFormat("en-GB", { timeZone: "UTC",
+      month: "long",
+      year: "numeric",
+    });
+
+    await expect.poll(headingText).toBe(formatter.formatRange(start, end));
+  });
+
+  it("can customise the month heading via slot", async () => {
+    const calendar = await mount(
+      <Fixture value="2024-07-10">
+        <CalendarMonth>
+          <CalendarHeading slot="heading" month="short" year="numeric" />
+        </CalendarMonth>
+      </Fixture>
+    );
+
+    const month = getMonth(calendar);
+    const headingText = getSlottedHeadingText(month);
+
+    const formatter = new Intl.DateTimeFormat("en-GB", { timeZone: "UTC",
+      month: "short",
+      year: "numeric",
+    });
+    const expected = formatter.format(toDate(new PlainYearMonth(2024, 7)));
+
+    await expect.poll(headingText).toBe(expected);
+  });
+
+  it("respects the locale", async () => {
+    const calendar = await mount(
+      <Fixture value="2024-03-15" locale="de-DE">
+        <CalendarHeading slot="heading" month="long" year="numeric" />
+        <CalendarMonth />
+      </Fixture>
+    );
+
+    const headingText = getSlottedHeadingText(calendar);
+    const formatter = new Intl.DateTimeFormat("de-DE", { timeZone: "UTC",
+      month: "long",
+      year: "numeric",
+    });
+    const expected = formatter.format(toDate(new PlainYearMonth(2024, 3)));
+
+    await expect.poll(headingText).toBe(expected);
+  });
+});

--- a/src/calendar-heading/calendar-heading.test.tsx
+++ b/src/calendar-heading/calendar-heading.test.tsx
@@ -1,6 +1,11 @@
 import { describe, it, expect } from "vitest";
 import type { VNodeAny } from "atomico/types/vnode";
-import { mount, getMonth, type CalendarInstance, type MonthInstance } from "../utils/test.js";
+import {
+  mount,
+  getMonth,
+  type CalendarInstance,
+  type MonthInstance,
+} from "../utils/test.js";
 import { CalendarMonth } from "../calendar-month/calendar-month.js";
 import { CalendarDate } from "../calendar-date/calendar-date.js";
 import { CalendarHeading } from "./calendar-heading.js";
@@ -22,7 +27,7 @@ function getSlottedHeadingText(root: CalendarInstance | MonthInstance) {
     throw new Error("Could not find slotted calendar-heading");
   }
 
-  return () => heading.shadowRoot?.textContent ?? heading.textContent ?? "";
+  return heading.shadowRoot?.textContent;
 }
 
 describe("CalendarHeading", () => {
@@ -31,17 +36,18 @@ describe("CalendarHeading", () => {
       <Fixture value="2024-03-15">
         <CalendarHeading slot="heading" month="short" year="2-digit" />
         <CalendarMonth />
-      </Fixture>
+      </Fixture>,
     );
 
     const headingText = getSlottedHeadingText(calendar);
-    const formatter = new Intl.DateTimeFormat("en-GB", { timeZone: "UTC",
+    const formatter = new Intl.DateTimeFormat("en-GB", {
+      timeZone: "UTC",
       month: "short",
       year: "2-digit",
     });
     const expected = formatter.format(toDate(new PlainYearMonth(2024, 3)));
 
-    await expect.poll(headingText).toBe(expected);
+    expect(headingText).toBe(expected);
   });
 
   it("only includes options that are set", async () => {
@@ -49,14 +55,17 @@ describe("CalendarHeading", () => {
       <Fixture value="2024-09-01">
         <CalendarHeading slot="heading" month="long" />
         <CalendarMonth />
-      </Fixture>
+      </Fixture>,
     );
 
     const headingText = getSlottedHeadingText(calendar);
-    const formatter = new Intl.DateTimeFormat("en-GB", { timeZone: "UTC", month: "long" });
+    const formatter = new Intl.DateTimeFormat("en-GB", {
+      timeZone: "UTC",
+      month: "long",
+    });
     const expected = formatter.format(toDate(new PlainYearMonth(2024, 9)));
 
-    await expect.poll(headingText).toBe(expected);
+    expect(headingText).toBe(expected);
   });
 
   it("formats a range when showing multiple months", async () => {
@@ -65,18 +74,19 @@ describe("CalendarHeading", () => {
         <CalendarHeading slot="heading" month="long" year="numeric" />
         <CalendarMonth />
         <CalendarMonth offset={1} />
-      </Fixture>
+      </Fixture>,
     );
 
     const headingText = getSlottedHeadingText(calendar);
     const start = toDate(new PlainYearMonth(2023, 12));
     const end = toDate(new PlainYearMonth(2024, 1));
-    const formatter = new Intl.DateTimeFormat("en-GB", { timeZone: "UTC",
+    const formatter = new Intl.DateTimeFormat("en-GB", {
+      timeZone: "UTC",
       month: "long",
       year: "numeric",
     });
 
-    await expect.poll(headingText).toBe(formatter.formatRange(start, end));
+    expect(headingText).toBe(formatter.formatRange(start, end));
   });
 
   it("can customise the month heading via slot", async () => {
@@ -85,19 +95,20 @@ describe("CalendarHeading", () => {
         <CalendarMonth>
           <CalendarHeading slot="heading" month="short" year="numeric" />
         </CalendarMonth>
-      </Fixture>
+      </Fixture>,
     );
 
     const month = getMonth(calendar);
     const headingText = getSlottedHeadingText(month);
 
-    const formatter = new Intl.DateTimeFormat("en-GB", { timeZone: "UTC",
+    const formatter = new Intl.DateTimeFormat("en-GB", {
+      timeZone: "UTC",
       month: "short",
       year: "numeric",
     });
     const expected = formatter.format(toDate(new PlainYearMonth(2024, 7)));
 
-    await expect.poll(headingText).toBe(expected);
+    expect(headingText).toBe(expected);
   });
 
   it("respects the locale", async () => {
@@ -105,16 +116,17 @@ describe("CalendarHeading", () => {
       <Fixture value="2024-03-15" locale="de-DE">
         <CalendarHeading slot="heading" month="long" year="numeric" />
         <CalendarMonth />
-      </Fixture>
+      </Fixture>,
     );
 
     const headingText = getSlottedHeadingText(calendar);
-    const formatter = new Intl.DateTimeFormat("de-DE", { timeZone: "UTC",
+    const formatter = new Intl.DateTimeFormat("de-DE", {
+      timeZone: "UTC",
       month: "long",
       year: "numeric",
     });
     const expected = formatter.format(toDate(new PlainYearMonth(2024, 3)));
 
-    await expect.poll(headingText).toBe(expected);
+    expect(headingText).toBe(expected);
   });
 });

--- a/src/calendar-heading/calendar-heading.tsx
+++ b/src/calendar-heading/calendar-heading.tsx
@@ -1,0 +1,48 @@
+import { c, useContext, useMemo } from "atomico";
+import { CalendarHeadingContext } from "./CalendarHeadingContext.js";
+import { useDateFormatter } from "../utils/hooks.js";
+import { toDate } from "../utils/date.js";
+
+type DateFormatOptions = Pick<Intl.DateTimeFormatOptions, "year" | "month">;
+
+export const CalendarHeading = c(
+  (props) => {
+    const context = useContext(CalendarHeadingContext);
+
+    const options: DateFormatOptions = useMemo(() => {
+      const opts: DateFormatOptions = {};
+      if (props.year) opts.year = props.year;
+      if (props.month) opts.month = props.month;
+      return opts;
+    }, [props.year, props.month]);
+
+    const formatter = useDateFormatter(options, context.locale);
+
+    const formattedDate =
+      context.type === "range"
+        ? formatter.formatRange(toDate(context.value.start), toDate(context.value.end))
+        : formatter.format(toDate(context.value));
+
+    return <host shadowDom>{formattedDate}</host>;
+  },
+  {
+    props: {
+      year: {
+        type: String,
+        value: (): "numeric" | "2-digit" | undefined => undefined,
+      },
+      month: {
+        type: String,
+        value: ():
+          | "numeric"
+          | "2-digit"
+          | "long"
+          | "short"
+          | "narrow"
+          | undefined => undefined,
+      },
+    },
+  },
+);
+
+customElements.define("calendar-heading", CalendarHeading);

--- a/src/calendar-month/calendar-month.test.tsx
+++ b/src/calendar-month/calendar-month.test.tsx
@@ -689,7 +689,7 @@ describe("CalendarMonth", () => {
         .toHaveTextContent("D");
 
       const title = getMonthHeading(month);
-      await expect.element(title).toHaveTextContent("janvier");
+      await expect.poll(title).toContain("janvier");
 
       const button = getDayButton(month, "15 janvier");
       expect(button).toBeTruthy();

--- a/src/calendar-month/calendar-month.test.tsx
+++ b/src/calendar-month/calendar-month.test.tsx
@@ -26,7 +26,7 @@ import { toDate, getToday } from "../utils/date.js";
 
 async function nextFrame() {
   return new Promise((resolve) =>
-    requestAnimationFrame(() => resolve(undefined))
+    requestAnimationFrame(() => resolve(undefined)),
   );
 }
 
@@ -42,7 +42,8 @@ interface DateTestProps extends TestPropsBase, CalendarDateContext {}
 interface RangeTestProps extends TestPropsBase, CalendarRangeContext {}
 interface MultiTestProps extends TestPropsBase, CalendarMultiContext {}
 
-const isWeekend = (date: Date) => date.getUTCDay() === 0 || date.getUTCDay() === 6;
+const isWeekend = (date: Date) =>
+  date.getUTCDay() === 0 || date.getUTCDay() === 6;
 
 function getWeekNumbers(month: MonthInstance) {
   const grid = getGrid(month);
@@ -104,7 +105,7 @@ describe("CalendarMonth", () => {
             type="range"
             value={[]}
             focusedDate={PlainDate.from("2024-01-01")}
-          />
+          />,
         );
 
         const selected = getSelectedDays(month);
@@ -117,7 +118,7 @@ describe("CalendarMonth", () => {
             focusedDate={PlainDate.from("2020-01-01")}
             type="range"
             value={[PlainDate.from("2020-01-01"), PlainDate.from("2020-01-03")]}
-          />
+          />,
         );
 
         const selected = getSelectedDays(month);
@@ -146,7 +147,7 @@ describe("CalendarMonth", () => {
     describe("single date", () => {
       it("handles an empty value", async () => {
         const month = await mount(
-          <Fixture focusedDate={PlainDate.from("2024-01-01")} />
+          <Fixture focusedDate={PlainDate.from("2024-01-01")} />,
         );
 
         const selected = getSelectedDays(month);
@@ -158,7 +159,7 @@ describe("CalendarMonth", () => {
           <Fixture
             focusedDate={PlainDate.from("2020-01-01")}
             value={PlainDate.from("2020-01-01")}
-          />
+          />,
         );
 
         const selected = getSelectedDays(month);
@@ -177,7 +178,7 @@ describe("CalendarMonth", () => {
             type="multi"
             value={[]}
             focusedDate={PlainDate.from("2024-01-01")}
-          />
+          />,
         );
 
         const selected = getSelectedDays(month);
@@ -194,7 +195,7 @@ describe("CalendarMonth", () => {
               PlainDate.from("2020-01-02"),
               PlainDate.from("2020-01-03"),
             ]}
-          />
+          />,
         );
 
         const selected = getSelectedDays(month);
@@ -240,14 +241,14 @@ describe("CalendarMonth", () => {
 
       it("uses a roving tab index", async () => {
         const month = await mount(
-          <Fixture focusedDate={PlainDate.from("2020-01-01")} />
+          <Fixture focusedDate={PlainDate.from("2020-01-01")} />,
         );
         const grid = getGrid(month);
         const buttons = [...grid.querySelectorAll("button")];
 
         // all buttons have a tabindex
         expect(buttons.every((button) => button.hasAttribute("tabindex"))).toBe(
-          true
+          true,
         );
 
         // only one button has tabindex 0
@@ -268,7 +269,10 @@ describe("CalendarMonth", () => {
     it("can select a date", async () => {
       const spy = createSpy<(e: CustomEvent<PlainDate>) => void>();
       const calendar = await mount(
-        <Fixture focusedDate={PlainDate.from("2020-04-01")} onselectday={spy} />
+        <Fixture
+          focusedDate={PlainDate.from("2020-04-01")}
+          onselectday={spy}
+        />,
       );
 
       await clickDay(calendar, "19 April");
@@ -284,7 +288,7 @@ describe("CalendarMonth", () => {
           focusedDate={PlainDate.from("2020-01-03")}
           onselectday={spy}
           isDateDisallowed={isWeekend}
-        />
+        />,
       );
 
       const day = getDayButton(calendar, "4 January")!;
@@ -302,7 +306,7 @@ describe("CalendarMonth", () => {
     it("can select a date", async () => {
       const spy = createSpy<(e: CustomEvent<PlainDate>) => void>();
       await mount(
-        <Fixture focusedDate={PlainDate.from("2020-04-19")} onfocusday={spy} />
+        <Fixture focusedDate={PlainDate.from("2020-04-19")} onfocusday={spy} />,
       );
 
       await userEvent.keyboard("{Tab}");
@@ -319,7 +323,7 @@ describe("CalendarMonth", () => {
           focusedDate={PlainDate.from("2020-01-04")}
           onselectday={spy}
           isDateDisallowed={isWeekend}
-        />
+        />,
       );
 
       await userEvent.keyboard("{Tab}");
@@ -331,7 +335,7 @@ describe("CalendarMonth", () => {
     it("can move focus to previous day", async () => {
       const spy = createSpy<(e: CustomEvent<PlainDate>) => void>();
       await mount(
-        <Fixture focusedDate={PlainDate.from("2020-04-19")} onfocusday={spy} />
+        <Fixture focusedDate={PlainDate.from("2020-04-19")} onfocusday={spy} />,
       );
 
       await userEvent.keyboard("{Tab}");
@@ -344,7 +348,7 @@ describe("CalendarMonth", () => {
     it("can move focus to next day ", async () => {
       const spy = createSpy<(e: CustomEvent<PlainDate>) => void>();
       await mount(
-        <Fixture focusedDate={PlainDate.from("2020-04-19")} onfocusday={spy} />
+        <Fixture focusedDate={PlainDate.from("2020-04-19")} onfocusday={spy} />,
       );
 
       await userEvent.keyboard("{Tab}");
@@ -357,7 +361,7 @@ describe("CalendarMonth", () => {
     it("can move focus to previous week", async () => {
       const spy = createSpy<(e: CustomEvent<PlainDate>) => void>();
       await mount(
-        <Fixture focusedDate={PlainDate.from("2020-04-19")} onfocusday={spy} />
+        <Fixture focusedDate={PlainDate.from("2020-04-19")} onfocusday={spy} />,
       );
 
       await userEvent.keyboard("{Tab}");
@@ -370,7 +374,7 @@ describe("CalendarMonth", () => {
     it("can move focus to next week", async () => {
       const spy = createSpy<(e: CustomEvent<PlainDate>) => void>();
       await mount(
-        <Fixture focusedDate={PlainDate.from("2020-04-19")} onfocusday={spy} />
+        <Fixture focusedDate={PlainDate.from("2020-04-19")} onfocusday={spy} />,
       );
 
       await userEvent.keyboard("{Tab}");
@@ -383,7 +387,7 @@ describe("CalendarMonth", () => {
     it("can move focus to start of week", async () => {
       const spy = createSpy<(e: CustomEvent<PlainDate>) => void>();
       await mount(
-        <Fixture focusedDate={PlainDate.from("2020-04-16")} onfocusday={spy} />
+        <Fixture focusedDate={PlainDate.from("2020-04-16")} onfocusday={spy} />,
       );
 
       await userEvent.keyboard("{Tab}");
@@ -396,7 +400,7 @@ describe("CalendarMonth", () => {
     it("can move focus to end of week", async () => {
       const spy = createSpy<(e: CustomEvent<PlainDate>) => void>();
       await mount(
-        <Fixture focusedDate={PlainDate.from("2020-04-16")} onfocusday={spy} />
+        <Fixture focusedDate={PlainDate.from("2020-04-16")} onfocusday={spy} />,
       );
 
       await userEvent.keyboard("{Tab}");
@@ -409,7 +413,7 @@ describe("CalendarMonth", () => {
     it("can move focus to previous month", async () => {
       const spy = createSpy<(e: CustomEvent<PlainDate>) => void>();
       await mount(
-        <Fixture focusedDate={PlainDate.from("2020-04-19")} onfocusday={spy} />
+        <Fixture focusedDate={PlainDate.from("2020-04-19")} onfocusday={spy} />,
       );
 
       await userEvent.keyboard("{Tab}");
@@ -422,7 +426,7 @@ describe("CalendarMonth", () => {
     it("can move focus to next month", async () => {
       const spy = createSpy<(e: CustomEvent<PlainDate>) => void>();
       await mount(
-        <Fixture focusedDate={PlainDate.from("2020-04-19")} onfocusday={spy} />
+        <Fixture focusedDate={PlainDate.from("2020-04-19")} onfocusday={spy} />,
       );
 
       await userEvent.keyboard("{Tab}");
@@ -435,7 +439,7 @@ describe("CalendarMonth", () => {
     it("can move focus to previous year", async () => {
       const spy = createSpy<(e: CustomEvent<PlainDate>) => void>();
       await mount(
-        <Fixture focusedDate={PlainDate.from("2020-04-19")} onfocusday={spy} />
+        <Fixture focusedDate={PlainDate.from("2020-04-19")} onfocusday={spy} />,
       );
 
       await userEvent.keyboard("{Tab}");
@@ -448,7 +452,7 @@ describe("CalendarMonth", () => {
     it("can move focus to next year", async () => {
       const spy = createSpy<(e: CustomEvent<PlainDate>) => void>();
       await mount(
-        <Fixture focusedDate={PlainDate.from("2020-04-19")} onfocusday={spy} />
+        <Fixture focusedDate={PlainDate.from("2020-04-19")} onfocusday={spy} />,
       );
 
       await userEvent.keyboard("{Tab}");
@@ -467,7 +471,7 @@ describe("CalendarMonth", () => {
           focusedDate={PlainDate.from("2020-01-03")}
           onfocusday={spy}
           isDateDisallowed={isWeekend}
-        />
+        />,
       );
 
       await userEvent.keyboard("{Tab}");
@@ -486,7 +490,7 @@ describe("CalendarMonth", () => {
           max={PlainDate.from(focused)}
           focusedDate={PlainDate.from(focused)}
           onfocusday={spy}
-        />
+        />,
       );
 
       await userEvent.keyboard("{Tab}");
@@ -505,7 +509,7 @@ describe("CalendarMonth", () => {
             focusedDate={PlainDate.from("2020-04-19")}
             onfocusday={spy}
             dir="rtl"
-          />
+          />,
         );
 
         await userEvent.keyboard("{Tab}");
@@ -522,7 +526,7 @@ describe("CalendarMonth", () => {
             focusedDate={PlainDate.from("2020-04-19")}
             onfocusday={spy}
             dir="rtl"
-          />
+          />,
         );
 
         await userEvent.keyboard("{Tab}");
@@ -542,7 +546,7 @@ describe("CalendarMonth", () => {
           focusedDate={PlainDate.from("2020-01-15")}
           min={PlainDate.from("2020-01-02")}
           onselectday={spy}
-        />
+        />,
       );
 
       // try clicking a day outside the range
@@ -563,7 +567,7 @@ describe("CalendarMonth", () => {
           focusedDate={PlainDate.from("2020-01-15")}
           max={PlainDate.from("2020-01-30")}
           onselectday={spy}
-        />
+        />,
       );
 
       // try clicking a day outside the range
@@ -585,7 +589,7 @@ describe("CalendarMonth", () => {
           min={PlainDate.from("2020-01-02")}
           max={PlainDate.from("2020-01-30")}
           onselectday={spy}
-        />
+        />,
       );
 
       // try clicking a day less than min
@@ -609,7 +613,7 @@ describe("CalendarMonth", () => {
         <Fixture
           focusedDate={PlainDate.from("2020-01-01")}
           today={PlainDate.from("2020-01-02")}
-        />
+        />,
       );
 
       const todayButton = getTodayButton(month);
@@ -621,7 +625,7 @@ describe("CalendarMonth", () => {
 
   it("can show outside days", async () => {
     const month = await mount(
-      <Fixture focusedDate={PlainDate.from("2020-04-01")} showOutsideDays />
+      <Fixture focusedDate={PlainDate.from("2020-04-01")} showOutsideDays />,
     );
 
     const outsideMarch = getDayButton(month, "30 March");
@@ -634,12 +638,12 @@ describe("CalendarMonth", () => {
   describe("localization", async () => {
     it("localizes days and months", async () => {
       const month = await mount(
-        <Fixture focusedDate={PlainDate.from("2020-01-15")} locale="fr-FR" />
+        <Fixture focusedDate={PlainDate.from("2020-01-15")} locale="fr-FR" />,
       );
       const grid = getGrid(month);
 
       const accessibleHeadings = grid.querySelectorAll(
-        "th span:not([aria-hidden])"
+        "th span:not([aria-hidden])",
       );
       await expect
         .element(page.elementLocator(accessibleHeadings[0]!))
@@ -664,7 +668,7 @@ describe("CalendarMonth", () => {
         .toHaveTextContent("dimanche");
 
       const visualHeadings = grid.querySelectorAll(
-        "th span[aria-hidden='true']"
+        "th span[aria-hidden='true']",
       );
       await expect
         .element(page.elementLocator(visualHeadings[0]!))
@@ -688,8 +692,7 @@ describe("CalendarMonth", () => {
         .element(page.elementLocator(visualHeadings[6]!))
         .toHaveTextContent("D");
 
-      const title = getMonthHeading(month);
-      await expect.poll(title).toContain("janvier");
+      expect(getMonthHeading(month)).toEqual("janvier");
 
       const button = getDayButton(month, "15 janvier");
       expect(button).toBeTruthy();
@@ -700,12 +703,12 @@ describe("CalendarMonth", () => {
         <Fixture
           focusedDate={PlainDate.from("2020-01-15")}
           formatWeekday="short"
-        />
+        />,
       );
       const grid = getGrid(month);
 
       const accessibleHeadings = grid.querySelectorAll(
-        "th span:not([aria-hidden])"
+        "th span:not([aria-hidden])",
       );
       await expect
         .element(page.elementLocator(accessibleHeadings[0]!))
@@ -730,7 +733,7 @@ describe("CalendarMonth", () => {
         .toHaveTextContent("Sunday");
 
       const visualHeadings = grid.querySelectorAll(
-        "th span[aria-hidden='true']"
+        "th span[aria-hidden='true']",
       );
       await expect
         .element(page.elementLocator(visualHeadings[0]!))
@@ -764,7 +767,7 @@ describe("CalendarMonth", () => {
         <Fixture
           focusedDate={PlainDate.from("2020-01-15")}
           firstDayOfWeek={firstDayOfWeek}
-        />
+        />,
       );
       const grid = getGrid(month);
 
@@ -789,7 +792,7 @@ describe("CalendarMonth", () => {
   describe("week numbers", () => {
     it("supports week numbering", async () => {
       const month = await mount(
-        <Fixture focusedDate={PlainDate.from("2020-04-01")} showWeekNumbers />
+        <Fixture focusedDate={PlainDate.from("2020-04-01")} showWeekNumbers />,
       );
 
       const weekNumbers = getWeekNumbers(month);
@@ -824,7 +827,7 @@ describe("CalendarMonth", () => {
           focusedDate={PlainDate.from("2027-01-01")}
           showWeekNumbers
           firstDayOfWeek={1}
-        />
+        />,
       );
 
       const weekNumbers = getWeekNumbers(month);
@@ -851,7 +854,7 @@ describe("CalendarMonth", () => {
           focusedDate={PlainDate.from("2020-01-01")}
           showWeekNumbers
           firstDayOfWeek={1}
-        />
+        />,
       );
 
       const weekNumbers = getWeekNumbers(month);

--- a/src/calendar-month/calendar-month.tsx
+++ b/src/calendar-month/calendar-month.tsx
@@ -2,7 +2,8 @@ import { c, css, useContext, useRef, type Host } from "atomico";
 import { reset, vh } from "../utils/styles.js";
 import { useCalendarMonth } from "./useCalendarMonth.js";
 import { CalendarContext } from "./CalendarMonthContext.js";
-import { getWeekNumber, toDate } from "../utils/date.js";
+import { CalendarHeading } from "../calendar-heading/calendar-heading.js";
+import { getWeekNumber } from "../utils/date.js";
 
 const mapToDayNumber = (firstDayOfWeek: number, i: number) =>
   (i + firstDayOfWeek) % 7;
@@ -25,9 +26,11 @@ export const CalendarMonth = c(
 
     return (
       <host shadowDom focus={focus}>
-        <div id="h" part="heading">
-          {calendar.formatter.format(toDate(calendar.yearMonth))}
-        </div>
+        <CalendarHeading month="long" id="h" class="vh" />
+
+        <slot name="heading" part="heading">
+          <CalendarHeading month="long" aria-hidden="true" />
+        </slot>
 
         <table ref={table} aria-labelledby="h" part="table">
           <colgroup>

--- a/src/calendar-month/useCalendarMonth.ts
+++ b/src/calendar-month/useCalendarMonth.ts
@@ -1,4 +1,5 @@
-import { useEvent, useMemo } from "atomico";
+import { useEvent, useMemo, useProvider } from "atomico";
+import { CalendarHeadingContext } from "../calendar-heading/CalendarHeadingContext.js";
 import { useDayNames, useDateFormatter } from "../utils/hooks.js";
 import {
   clamp,
@@ -17,7 +18,6 @@ const inRange = (date: PlainDate, min?: PlainDate, max?: PlainDate) =>
 const isLTR = (e: Event) => (e.target as HTMLElement).matches(":dir(ltr)");
 
 const dayOptions = { month: "long", day: "numeric" } as const;
-const monthOptions = { month: "long" } as const;
 const longDayOptions = { weekday: "long" } as const;
 const dispatchOptions = { bubbles: true };
 
@@ -48,12 +48,13 @@ export function useCalendarMonth({ props, context }: UseCalendarMonthOptions) {
   );
   const daysVisible = useDayNames(visibleDayOptions, firstDayOfWeek, locale);
   const dayFormatter = useDateFormatter(dayOptions, locale);
-  const formatter = useDateFormatter(monthOptions, locale);
 
   const yearMonth = useMemo(
     () => page.start.add({ months: offset }),
     [page, offset]
   );
+
+  useProvider(CalendarHeadingContext, { type: "date", value: yearMonth, locale });
 
   const weeks = useMemo(
     () => getViewOfMonth(yearMonth, firstDayOfWeek),
@@ -181,7 +182,6 @@ export function useCalendarMonth({ props, context }: UseCalendarMonthOptions) {
     yearMonth,
     daysLong,
     daysVisible,
-    formatter,
     getDayProps,
   };
 }

--- a/src/calendar-multi/calendar-multi.test.tsx
+++ b/src/calendar-multi/calendar-multi.test.tsx
@@ -173,7 +173,7 @@ describe("CalendarMulti", () => {
       const fifth = getDayButton(month, "5 January");
       const tenth = getDayButton(month, "10 January");
 
-      await expect.element(getMonthHeading(month)).toHaveTextContent("January");
+      await expect.poll(getMonthHeading(month)).toContain("January");
       await expect.element(page.elementLocator(fifth)).toHaveAttribute("aria-pressed", "true");
       await expect.element(page.elementLocator(tenth)).toHaveAttribute("aria-pressed", "true");
     });

--- a/src/calendar-multi/calendar-multi.test.tsx
+++ b/src/calendar-multi/calendar-multi.test.tsx
@@ -44,7 +44,7 @@ describe("CalendarMulti", () => {
     it("can select a multiple days", async () => {
       const spy = createSpy<(e: Event) => void>();
       const calendar = await mount(
-        <Fixture value="2020-01-01 2020-01-03" onchange={spy} />
+        <Fixture value="2020-01-01 2020-01-03" onchange={spy} />,
       );
 
       const month = getMonth(calendar);
@@ -62,7 +62,7 @@ describe("CalendarMulti", () => {
       await clickDay(month, "22 April");
       expect(spy.count).toBe(2);
       expect(calendar.value).toBe(
-        "2020-01-01 2020-01-03 2020-04-19 2020-04-22"
+        "2020-01-01 2020-01-03 2020-04-19 2020-04-22",
       );
 
       // deselect
@@ -99,9 +99,7 @@ describe("CalendarMulti", () => {
       await userEvent.keyboard("{Enter}");
 
       expect(spy.count).toBe(1);
-      expect(spy.last[0].target.value).toBe(
-        "2020-01-01 2020-01-03 2020-04-19"
-      );
+      expect(spy.last[0].target.value).toBe("2020-01-01 2020-01-03 2020-04-19");
 
       // select 22nd of month
       await userEvent.keyboard("{ArrowRight}");
@@ -111,15 +109,13 @@ describe("CalendarMulti", () => {
 
       expect(spy.count).toBe(2);
       expect(spy.last[0].target.value).toBe(
-        "2020-01-01 2020-01-03 2020-04-19 2020-04-22"
+        "2020-01-01 2020-01-03 2020-04-19 2020-04-22",
       );
 
       // deselect 22nd of month
       await userEvent.keyboard("{Enter}");
       expect(spy.count).toBe(3);
-      expect(spy.last[0].target.value).toBe(
-        "2020-01-01 2020-01-03 2020-04-19"
-      );
+      expect(spy.last[0].target.value).toBe("2020-01-01 2020-01-03 2020-04-19");
     });
   });
 
@@ -127,7 +123,7 @@ describe("CalendarMulti", () => {
     it("raises a change event", async () => {
       const spy = createSpy<(e: Event) => void>();
       const calendar = await mount(
-        <Fixture value="2022-01-01 2022-01-03" onchange={spy} />
+        <Fixture value="2022-01-01 2022-01-03" onchange={spy} />,
       );
 
       const month = getMonth(calendar);
@@ -140,7 +136,7 @@ describe("CalendarMulti", () => {
       await clickDay(month, "30 December");
       expect(spy.count).toBe(2);
       expect(calendar.value).toBe(
-        "2022-01-01 2022-01-03 2021-12-31 2021-12-30"
+        "2022-01-01 2022-01-03 2021-12-31 2021-12-30",
       );
     });
   });
@@ -151,7 +147,9 @@ describe("CalendarMulti", () => {
       const month = getMonth(calendar);
 
       const day = getDayButton(month, "5 January");
-      await expect.element(page.elementLocator(day)).toHaveAttribute("tabindex", "0");
+      await expect
+        .element(page.elementLocator(day))
+        .toHaveAttribute("tabindex", "0");
     });
   });
 
@@ -166,16 +164,20 @@ describe("CalendarMulti", () => {
               </div>
             </div>
           </div>
-        </Fixture>
+        </Fixture>,
       );
 
       const month = getMonth(calendar);
       const fifth = getDayButton(month, "5 January");
       const tenth = getDayButton(month, "10 January");
 
-      await expect.poll(getMonthHeading(month)).toContain("January");
-      await expect.element(page.elementLocator(fifth)).toHaveAttribute("aria-pressed", "true");
-      await expect.element(page.elementLocator(tenth)).toHaveAttribute("aria-pressed", "true");
+      expect(getMonthHeading(month)).toEqual("January");
+      await expect
+        .element(page.elementLocator(fifth))
+        .toHaveAttribute("aria-pressed", "true");
+      await expect
+        .element(page.elementLocator(tenth))
+        .toHaveAttribute("aria-pressed", "true");
     });
   });
 });

--- a/src/calendar-range/calendar-range.test.tsx
+++ b/src/calendar-range/calendar-range.test.tsx
@@ -282,7 +282,7 @@ describe("CalendarRange", () => {
       const sixth = getDayButton(month, "6 January");
       const seventh = getDayButton(month, "7 January");
 
-      await expect.element(getMonthHeading(month)).toHaveTextContent("January");
+      await expect.poll(getMonthHeading(month)).toContain("January");
       await expect.element(page.elementLocator(fifth)).toHaveAttribute("aria-pressed", "true");
       await expect.element(page.elementLocator(sixth)).toHaveAttribute("aria-pressed", "true");
       await expect.element(page.elementLocator(seventh)).toHaveAttribute("aria-pressed", "true");

--- a/src/calendar-range/calendar-range.test.tsx
+++ b/src/calendar-range/calendar-range.test.tsx
@@ -49,7 +49,7 @@ describe("CalendarRange", () => {
     it("can select a range: start -> end", async () => {
       const spy = createSpy();
       const calendar = await mount(
-        <Fixture value="2020-01-01/2020-01-01" onchange={spy} />
+        <Fixture value="2020-01-01/2020-01-01" onchange={spy} />,
       );
       const month = getMonth(calendar);
 
@@ -70,7 +70,7 @@ describe("CalendarRange", () => {
     it("can select a range: end -> start", async () => {
       const spy = createSpy();
       const calendar = await mount(
-        <Fixture value="2020-01-01/2020-01-01" onchange={spy} />
+        <Fixture value="2020-01-01/2020-01-01" onchange={spy} />,
       );
       const month = getMonth(calendar);
       const nextMonth = getNextPageButton(calendar);
@@ -161,7 +161,7 @@ describe("CalendarRange", () => {
     it("raises a focusday event", async () => {
       const spy = createSpy<(e: CustomEvent<Date>) => void>();
       const calendar = await mount(
-        <Fixture value="2022-01-01/2022-01-01" onfocusday={spy} />
+        <Fixture value="2022-01-01/2022-01-01" onfocusday={spy} />,
       );
 
       // click next button
@@ -174,7 +174,7 @@ describe("CalendarRange", () => {
     it("raises a change event", async () => {
       const spy = createSpy<(e: Event) => void>();
       const calendar = await mount(
-        <Fixture value="2022-01-01/2022-01-01" onchange={spy} />
+        <Fixture value="2022-01-01/2022-01-01" onchange={spy} />,
       );
 
       const month = getMonth(calendar);
@@ -197,7 +197,7 @@ describe("CalendarRange", () => {
           value="2022-01-01/2022-01-01"
           onrangestart={startSpy}
           onrangeend={endSpy}
-        />
+        />,
       );
 
       const month = getMonth(calendar);
@@ -221,14 +221,16 @@ describe("CalendarRange", () => {
       const month = getMonth(calendar);
 
       const day = getDayButton(month, "5 January");
-      await expect.element(page.elementLocator(day)).toHaveAttribute("tabindex", "0");
+      await expect
+        .element(page.elementLocator(day))
+        .toHaveAttribute("tabindex", "0");
     });
   });
 
   describe("tentative date", () => {
     it("can be set", async () => {
       const calendar = await mount(
-        <Fixture focusedDate="2024-04-01" tentative="2024-04-19" />
+        <Fixture focusedDate="2024-04-01" tentative="2024-04-19" />,
       );
       const month = getMonth(calendar);
 
@@ -240,7 +242,7 @@ describe("CalendarRange", () => {
 
     it("can be cleared", async () => {
       const calendar = await mount<InstanceType<typeof CalendarRange>>(
-        <Fixture focusedDate="2024-04-01" />
+        <Fixture focusedDate="2024-04-01" />,
       );
       const month = getMonth(calendar);
 
@@ -274,7 +276,7 @@ describe("CalendarRange", () => {
               </div>
             </div>
           </div>
-        </Fixture>
+        </Fixture>,
       );
 
       const month = getMonth(calendar);
@@ -282,10 +284,16 @@ describe("CalendarRange", () => {
       const sixth = getDayButton(month, "6 January");
       const seventh = getDayButton(month, "7 January");
 
-      await expect.poll(getMonthHeading(month)).toContain("January");
-      await expect.element(page.elementLocator(fifth)).toHaveAttribute("aria-pressed", "true");
-      await expect.element(page.elementLocator(sixth)).toHaveAttribute("aria-pressed", "true");
-      await expect.element(page.elementLocator(seventh)).toHaveAttribute("aria-pressed", "true");
+      expect(getMonthHeading(month)).toEqual("January");
+      await expect
+        .element(page.elementLocator(fifth))
+        .toHaveAttribute("aria-pressed", "true");
+      await expect
+        .element(page.elementLocator(sixth))
+        .toHaveAttribute("aria-pressed", "true");
+      await expect
+        .element(page.elementLocator(seventh))
+        .toHaveAttribute("aria-pressed", "true");
     });
   });
 });

--- a/src/calendar-year-month/calendar-select-year-month.test.tsx
+++ b/src/calendar-year-month/calendar-select-year-month.test.tsx
@@ -69,12 +69,12 @@ describe("CalendarSelectMonth / CalendarSelectYear", () => {
     const monthSelect = getMonthSelect(calendar);
 
     expect(monthSelect.value).toBe("12");
-    await expect.poll(getCalendarHeading(calendar)).toContain("December 2025");
+    expect(getCalendarHeading(calendar)).toEqual("December 2025");
 
     await userEvent.selectOptions(monthSelect, "11");
 
     expect(monthSelect.value).toBe("11");
-    await expect.poll(getCalendarHeading(calendar)).toContain("November 2025");
+    expect(getCalendarHeading(calendar)).toEqual("November 2025");
   });
 
   it("can change the year", async () => {
@@ -82,17 +82,17 @@ describe("CalendarSelectMonth / CalendarSelectYear", () => {
     const yearSelect = getYearSelect(calendar);
 
     expect(yearSelect.value).toBe("2025");
-    await expect.poll(getCalendarHeading(calendar)).toContain("December 2025");
+    expect(getCalendarHeading(calendar)).toEqual("December 2025");
 
     await userEvent.selectOptions(yearSelect, "2026");
 
     expect(yearSelect.value).toBe("2026");
-    await expect.poll(getCalendarHeading(calendar)).toContain("December 2026");
+    expect(getCalendarHeading(calendar)).toEqual("December 2026");
   });
 
   it("handles min and max dates", async () => {
     const calendar = await mount(
-      <Fixture value="2025-06-01" min="2024-06-01" max="2026-02-01" />
+      <Fixture value="2025-06-01" min="2024-06-01" max="2026-02-01" />,
     );
 
     const monthSelect = getMonthSelect(calendar);
@@ -109,7 +109,7 @@ describe("CalendarSelectMonth / CalendarSelectYear", () => {
       [...monthSelect.options].map((o) => ({
         label: o.label,
         disabled: o.disabled,
-      }))
+      })),
     ).toEqual([
       { label: "January", disabled: false },
       { label: "February", disabled: false },
@@ -133,7 +133,7 @@ describe("CalendarSelectMonth / CalendarSelectYear", () => {
       [...monthSelect.options].map((o) => ({
         label: o.label,
         disabled: o.disabled,
-      }))
+      })),
     ).toEqual([
       { label: "January", disabled: true },
       { label: "February", disabled: true },
@@ -154,7 +154,7 @@ describe("CalendarSelectMonth / CalendarSelectYear", () => {
     // Bug reported in #113: when min="2026-01-02", January should not be disabled
     // because days 2-31 are valid, but the old logic disabled it
     const calendar = await mount(
-      <Fixture value="2026-01-15" min="2026-01-02" max="2026-03-15" />
+      <Fixture value="2026-01-15" min="2026-01-02" max="2026-03-15" />,
     );
 
     const monthSelect = getMonthSelect(calendar);
@@ -165,12 +165,12 @@ describe("CalendarSelectMonth / CalendarSelectYear", () => {
       [...monthSelect.options].map((o) => ({
         label: o.label,
         disabled: o.disabled,
-      }))
+      })),
     ).toEqual([
-      { label: "January", disabled: false },  // Should be enabled (days 2-31 valid)
+      { label: "January", disabled: false }, // Should be enabled (days 2-31 valid)
       { label: "February", disabled: false },
-      { label: "March", disabled: false },    // Should be enabled (days 1-15 valid)
-      { label: "April", disabled: true },     // Should be disabled (all days after max)
+      { label: "March", disabled: false }, // Should be enabled (days 1-15 valid)
+      { label: "April", disabled: true }, // Should be disabled (all days after max)
       { label: "May", disabled: true },
       { label: "June", disabled: true },
       { label: "July", disabled: true },
@@ -184,7 +184,7 @@ describe("CalendarSelectMonth / CalendarSelectYear", () => {
 
   it("can render month names in long format", async () => {
     const calendar = await mount(
-      <Fixture value="2025-12-15" formatMonth="long" />
+      <Fixture value="2025-12-15" formatMonth="long" />,
     );
 
     const monthSelect = getMonthSelect(calendar);
@@ -206,7 +206,7 @@ describe("CalendarSelectMonth / CalendarSelectYear", () => {
 
   it("can render month names in short format", async () => {
     const calendar = await mount(
-      <Fixture value="2025-12-15" formatMonth="short" />
+      <Fixture value="2025-12-15" formatMonth="short" />,
     );
 
     const monthSelect = getMonthSelect(calendar);
@@ -227,9 +227,7 @@ describe("CalendarSelectMonth / CalendarSelectYear", () => {
   });
 
   it("respects maxYears prop", async () => {
-    const calendar = await mount(
-      <Fixture value="2025-12-15" maxYears={6} />
-    );
+    const calendar = await mount(<Fixture value="2025-12-15" maxYears={6} />);
 
     const yearSelect = getYearSelect(calendar);
     expect([...yearSelect.options].map((o) => o.label)).toEqual([
@@ -243,9 +241,7 @@ describe("CalendarSelectMonth / CalendarSelectYear", () => {
   });
 
   it("centers years around current year when no min/max", async () => {
-    const calendar = await mount(
-      <Fixture value="2025-12-15" maxYears={10} />
-    );
+    const calendar = await mount(<Fixture value="2025-12-15" maxYears={10} />);
 
     const yearSelect = getYearSelect(calendar);
     expect([...yearSelect.options].map((o) => o.label)).toEqual([
@@ -264,7 +260,12 @@ describe("CalendarSelectMonth / CalendarSelectYear", () => {
 
   it("respects min/max range when smaller than maxYears", async () => {
     const calendar = await mount(
-      <Fixture value="2025-06-01" min="2024-01-01" max="2026-12-31" maxYears={20} />
+      <Fixture
+        value="2025-06-01"
+        min="2024-01-01"
+        max="2026-12-31"
+        maxYears={20}
+      />,
     );
 
     const yearSelect = getYearSelect(calendar);
@@ -277,7 +278,7 @@ describe("CalendarSelectMonth / CalendarSelectYear", () => {
 
   it("constrains centered range when min is set", async () => {
     const calendar = await mount(
-      <Fixture value="2025-01-01" min="2023-01-01" maxYears={10} />
+      <Fixture value="2025-01-01" min="2023-01-01" maxYears={10} />,
     );
 
     const yearSelect = getYearSelect(calendar);
@@ -295,7 +296,7 @@ describe("CalendarSelectMonth / CalendarSelectYear", () => {
 
   it("constrains centered range when max is set", async () => {
     const calendar = await mount(
-      <Fixture value="2025-12-31" max="2027-12-31" maxYears={10} />
+      <Fixture value="2025-12-31" max="2027-12-31" maxYears={10} />,
     );
 
     const yearSelect = getYearSelect(calendar);

--- a/src/calendar-year-month/calendar-select-year-month.test.tsx
+++ b/src/calendar-year-month/calendar-select-year-month.test.tsx
@@ -69,12 +69,12 @@ describe("CalendarSelectMonth / CalendarSelectYear", () => {
     const monthSelect = getMonthSelect(calendar);
 
     expect(monthSelect.value).toBe("12");
-    await expect.element(getCalendarHeading(calendar)).toHaveTextContent("December 2025");
+    await expect.poll(getCalendarHeading(calendar)).toContain("December 2025");
 
     await userEvent.selectOptions(monthSelect, "11");
 
     expect(monthSelect.value).toBe("11");
-    await expect.element(getCalendarHeading(calendar)).toHaveTextContent("November 2025");
+    await expect.poll(getCalendarHeading(calendar)).toContain("November 2025");
   });
 
   it("can change the year", async () => {
@@ -82,12 +82,12 @@ describe("CalendarSelectMonth / CalendarSelectYear", () => {
     const yearSelect = getYearSelect(calendar);
 
     expect(yearSelect.value).toBe("2025");
-    await expect.element(getCalendarHeading(calendar)).toHaveTextContent("December 2025");
+    await expect.poll(getCalendarHeading(calendar)).toContain("December 2025");
 
     await userEvent.selectOptions(yearSelect, "2026");
 
     expect(yearSelect.value).toBe("2026");
-    await expect.element(getCalendarHeading(calendar)).toHaveTextContent("December 2026");
+    await expect.poll(getCalendarHeading(calendar)).toContain("December 2026");
   });
 
   it("handles min and max dates", async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { CalendarSelectYear } from "./calendar-year-month/calendar-select-year";
 import { CalendarSelectMonth } from "./calendar-year-month/calendar-select-month";
 import { CalendarRange } from "./calendar-range/calendar-range";
 import { CalendarMulti } from "./calendar-multi/calendar-multi";
+import { CalendarHeading } from "./calendar-heading/calendar-heading";
 
 export {
   CalendarMonth,
@@ -12,6 +13,7 @@ export {
   CalendarMulti,
   CalendarSelectYear,
   CalendarSelectMonth,
+  CalendarHeading,
 };
 
 import type { AtomicoThis } from "atomico/types/dom";
@@ -33,3 +35,4 @@ export type CalendarSelectYearProps = ComponentProps<typeof CalendarSelectYear>;
 export type CalendarSelectMonthProps = ComponentProps<
   typeof CalendarSelectMonth
 >;
+export type CalendarHeadingProps = ComponentProps<typeof CalendarHeading>;

--- a/src/utils/test.ts
+++ b/src/utils/test.ts
@@ -1,4 +1,4 @@
-import { userEvent, page } from "vitest/browser";
+import { userEvent, page, type Locator } from "vitest/browser";
 import { fixture } from "atomico/test-dom";
 import type { VNodeAny } from "atomico/types/vnode";
 import type { CalendarDate } from "../calendar-date/calendar-date.js";
@@ -7,7 +7,7 @@ import type { CalendarRange } from "../calendar-range/calendar-range.js";
 
 async function nextFrame() {
   return new Promise((resolve) =>
-    requestAnimationFrame(() => resolve(undefined))
+    requestAnimationFrame(() => resolve(undefined)),
   );
 }
 
@@ -71,24 +71,22 @@ export function getGrid(month: MonthInstance): HTMLTableElement {
   return month.shadowRoot!.querySelector(`[part="table"]`)!;
 }
 
-function getHeadingText(heading: HTMLElement): () => string {
-  return () => heading.shadowRoot?.textContent ?? heading.textContent ?? "";
-}
-
 export function getCalendarVisibleHeading(calendar: CalendarInstance) {
-  const slot = calendar.shadowRoot!.querySelector(`[part=heading]`);
-  const heading = slot?.querySelector<HTMLElement>(`[aria-hidden]`);
+  const heading = calendar
+    .shadowRoot!.querySelector(`slot[part="heading"]`)
+    ?.querySelector(`[aria-hidden="true"]`);
 
   if (!heading) {
-    throw new Error("Could not find visible heading for calendar");
+    throw new Error("No visible heading found for calendar");
   }
 
-  return getHeadingText(heading);
+  return heading?.shadowRoot?.textContent;
 }
 
 export function getCalendarHeading(calendar: CalendarInstance) {
-  const group = calendar.shadowRoot!.querySelector(`[role="group"]`)!;
+  const calendarLocator = page.elementLocator(calendar);
 
+  const group = calendarLocator.getByRole("group").element()!;
   const labelledById = group.getAttribute("aria-labelledby");
   if (!labelledById) {
     throw new Error("No aria-labelledby attribute found on group");
@@ -99,7 +97,7 @@ export function getCalendarHeading(calendar: CalendarInstance) {
     throw new Error("No heading found for calendar");
   }
 
-  return getHeadingText(heading);
+  return heading.shadowRoot?.textContent;
 }
 
 export function getMonthHeading(month: MonthInstance) {
@@ -115,12 +113,12 @@ export function getMonthHeading(month: MonthInstance) {
     throw new Error("No heading found for month");
   }
 
-  return getHeadingText(heading);
+  return heading.shadowRoot!.textContent;
 }
 
 export function getPrevPageButton(calendar: CalendarInstance) {
   const button = calendar.shadowRoot!.querySelector<HTMLButtonElement>(
-    `button[part~="previous"]`
+    `button[part~="previous"]`,
   )!;
   return page.elementLocator(button);
 }
@@ -128,14 +126,14 @@ export function getPrevPageButton(calendar: CalendarInstance) {
 export function getNextPageButton(calendar: CalendarInstance) {
   const button =
     calendar.shadowRoot!.querySelector<HTMLButtonElement>(
-      `button[part~="next"]`
+      `button[part~="next"]`,
     )!;
   return page.elementLocator(button);
 }
 
 export function getTodayButton(month: MonthInstance) {
   const button = month.shadowRoot!.querySelector<HTMLButtonElement>(
-    `button[part~="today"]`
+    `button[part~="today"]`,
   )!;
   return page.elementLocator(button);
 }
@@ -143,7 +141,7 @@ export function getTodayButton(month: MonthInstance) {
 export function getSelectedDays(month: MonthInstance) {
   return [
     ...month.shadowRoot!.querySelectorAll<HTMLButtonElement>(
-      `button[aria-pressed="true"]`
+      `button[aria-pressed="true"]`,
     ),
   ];
 }
@@ -156,14 +154,14 @@ export function getDayButton(month: MonthInstance, dateLabel: string) {
   }
 
   return grid.querySelector<HTMLButtonElement>(
-    `button[aria-label="${dateLabel}"]`
+    `button[aria-label="${dateLabel}"]`,
   )!;
 }
 
 export async function clickDay(
   month: MonthInstance,
   dateLabel: string,
-  options?: { force?: boolean }
+  options?: { force?: boolean },
 ) {
   const button = getDayButton(month, dateLabel);
 

--- a/src/utils/test.ts
+++ b/src/utils/test.ts
@@ -71,6 +71,10 @@ export function getGrid(month: MonthInstance): HTMLTableElement {
   return month.shadowRoot!.querySelector(`[part="table"]`)!;
 }
 
+function getHeadingText(heading: HTMLElement): () => string {
+  return () => heading.shadowRoot?.textContent ?? heading.textContent ?? "";
+}
+
 export function getCalendarVisibleHeading(calendar: CalendarInstance) {
   const slot = calendar.shadowRoot!.querySelector(`[part=heading]`);
   const heading = slot?.querySelector<HTMLElement>(`[aria-hidden]`);
@@ -79,7 +83,7 @@ export function getCalendarVisibleHeading(calendar: CalendarInstance) {
     throw new Error("Could not find visible heading for calendar");
   }
 
-  return page.elementLocator(heading);
+  return getHeadingText(heading);
 }
 
 export function getCalendarHeading(calendar: CalendarInstance) {
@@ -95,7 +99,7 @@ export function getCalendarHeading(calendar: CalendarInstance) {
     throw new Error("No heading found for calendar");
   }
 
-  return page.elementLocator(heading);
+  return getHeadingText(heading);
 }
 
 export function getMonthHeading(month: MonthInstance) {
@@ -111,7 +115,7 @@ export function getMonthHeading(month: MonthInstance) {
     throw new Error("No heading found for month");
   }
 
-  return page.elementLocator(heading);
+  return getHeadingText(heading);
 }
 
 export function getPrevPageButton(calendar: CalendarInstance) {


### PR DESCRIPTION
Fixes #25 

- adds new `<calendar-heading>` component for more flexible headings

```html
<calendar-date>
  <calendar-heading
    slot="heading"
    year="2-digit"
    month="long"
  ></calendar-heading>
 
  <calendar-month></calendar-month>
</calendar-date>
```