### PR TITLE
Add npm publishing workflow with OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,37 @@
+name: Publish to npm
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+# Only need OIDC for npm publishing - no repo write access needed
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build package
+        run: npx vite build
+
+      # Publish using OIDC trusted publishing (no token needed)
+      # Provenance is automatically generated with id-token: write permission
+      # Setup required: Configure this repo as a trusted publisher at:
+      # https://www.npmjs.com/package/cally/access
+      - name: Publish to npm
+        run: npm publish

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -1,0 +1,56 @@
+name: Bump Version
+
+on:
+  workflow_dispatch:
+    inputs:
+      version_type:
+        description: 'Version bump type'
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+
+# Need write permission to push version commit and tag
+permissions:
+  contents: write
+
+jobs:
+  version:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: |
+          npx playwright install chromium --with-deps
+          npm test
+
+      - name: Build
+        run: npm run build
+
+      # Git identity required for npm version to create commit
+      - name: Configure git
+        run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+
+      - name: Bump version
+        run: npm version ${{ inputs.version_type }}
+
+      # Push commit and tag (tag push triggers publish workflow)
+      - name: Push changes and tags
+        run: git push --follow-tags

--- a/package.json
+++ b/package.json
@@ -29,10 +29,7 @@
     "test:ui": "vitest --ui",
     "astro:dev": "astro dev --root ./docs",
     "astro:build": "astro check --root ./docs && astro build --root ./docs",
-    "astro:preview": "astro preview --root ./docs",
-    "preversion": "npm test",
-    "version": "npm run build",
-    "postversion": "git push origin main --tags && npm publish"
+    "astro:preview": "astro preview --root ./docs"
   },
   "dependencies": {
     "atomico": "^1.79.2"


### PR DESCRIPTION
- Add version.yml workflow for manual version bumping (patch/minor/major)
- Add publish.yml workflow that auto-triggers on v* tags
- Remove postversion, version, and preversion hooks from package.json
- Publish workflow uses OIDC (no npm token needed) with read-only repo access
- Version workflow tests, builds, bumps version, and pushes tag
- Docs auto-deploy via existing deploy.yml on tag push