### PR TITLE
Fix week number heading accessibility

### DIFF
--- a/src/calendar-month/calendar-month.tsx
+++ b/src/calendar-month/calendar-month.tsx
@@ -45,7 +45,8 @@ export const CalendarMonth = c(
               {context.showWeekNumbers && (
                 <th part="th weeknumber">
                   <slot name="weeknumber">
-                    <span aria-label="Week">#</span>
+                    <span class="vh">Week</span>
+                    <span aria-hidden="true">#</span>
                   </slot>
                 </th>
               )}


### PR DESCRIPTION
Replace invalid aria-label on non-interactive element with proper
visually hidden pattern using .vh class and aria-hidden, matching
the pattern used for day name headings.