### PR TITLE
Fix month selector skipping February on days >= 29

### DIFF
--- a/src/calendar-year-month/calendar-select-month.tsx
+++ b/src/calendar-year-month/calendar-select-month.tsx
@@ -22,6 +22,7 @@ function useCalendarSelectMonth(props: { formatMonth: "long" | "short" }) {
   const monthNames = useMemo(() => {
     const months = [];
     const day = new Date();
+    day.setUTCDate(1);
 
     for (var i = 0; i < 12; i++) {
       const index = (day.getUTCMonth() + 12) % 12;


### PR DESCRIPTION
When building the month name list, `new Date()` uses today's day-of-month. When that day is 29 or higher, incrementing the month to February causes JavaScript's Date to roll forward to March (since Feb doesn't have 29+ days in most years), skipping February entirely.

Set the UTC date to 1 before iterating months so every month is valid regardless of the current day.

Fixes #118 