### PR TITLE
Use PUBLISH_TOKEN instead of GITHUB_TOKEN in version workflow

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.PUBLISH_TOKEN }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary
Updated the version workflow to use a custom `PUBLISH_TOKEN` secret instead of the default `GITHUB_TOKEN` for repository checkout operations.

## Changes
- Replaced `secrets.GITHUB_TOKEN` with `secrets.PUBLISH_TOKEN` in the checkout step of the version workflow