### PR TITLE
Upgrade Node.js version from 20.x to 24.x in CI workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version: '24.x'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies


### PR DESCRIPTION
## Summary
Updates the Node.js runtime version used in the publish workflow from version 20.x to version 24.x.