### PR TITLE
Add automated issue notifications on release publication

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -52,8 +52,7 @@ jobs:
         id: tags
         run: |
           echo "current=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
-          previous=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || echo "")
-          echo "previous=$previous" >> "$GITHUB_OUTPUT"
+          echo "previous=$(git describe --tags --abbrev=0 HEAD^)" >> "$GITHUB_OUTPUT"
 
       - name: Comment on referenced issues
         env:
@@ -62,14 +61,8 @@ jobs:
           current="${{ steps.tags.outputs.current }}"
           previous="${{ steps.tags.outputs.previous }}"
 
-          if [ -z "$previous" ]; then
-            range="$current"
-          else
-            range="${previous}..${current}"
-          fi
-
           # Extract unique issue numbers referenced in commit messages
-          issues=$(git log "$range" --pretty=format:"%s %b" | grep -oP '#\K\d+' | sort -un)
+          issues=$(git log "${previous}..${current}" --pretty=format:"%s %b" | grep -oP '#\K\d+' | sort -un)
 
           for issue in $issues; do
             echo "Commenting on issue #$issue"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,3 +35,45 @@ jobs:
       # https://www.npmjs.com/package/cally/access
       - name: Publish to npm
         run: npm publish
+
+  notify-issues:
+    needs: publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get current and previous tags
+        id: tags
+        run: |
+          echo "current=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+          previous=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || echo "")
+          echo "previous=$previous" >> "$GITHUB_OUTPUT"
+
+      - name: Comment on referenced issues
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          current="${{ steps.tags.outputs.current }}"
+          previous="${{ steps.tags.outputs.previous }}"
+
+          if [ -z "$previous" ]; then
+            range="$current"
+          else
+            range="${previous}..${current}"
+          fi
+
+          # Extract unique issue numbers referenced in commit messages
+          issues=$(git log "$range" --pretty=format:"%s %b" | grep -oP '#\K\d+' | sort -un)
+
+          for issue in $issues; do
+            echo "Commenting on issue #$issue"
+            gh issue comment "$issue" \
+              --body "Released in [\`${current}\`](https://github.com/${{ github.repository }}/releases/tag/${current})" \
+              || echo "Skipping #$issue (not a commentable issue)"
+          done

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -54,19 +54,26 @@ jobs:
           echo "current=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
           echo "previous=$(git describe --tags --abbrev=0 HEAD^)" >> "$GITHUB_OUTPUT"
 
-      - name: Comment on referenced issues
+      - name: Comment on released issues
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           current="${{ steps.tags.outputs.current }}"
           previous="${{ steps.tags.outputs.previous }}"
 
-          # Extract unique issue numbers referenced in commit messages
-          issues=$(git log "${previous}..${current}" --pretty=format:"%s %b" | grep -oP '#\K\d+' | sort -un)
+          # Extract PR numbers from merge commit messages, e.g. "Fix bug (#119)"
+          prs=$(git log "${previous}..${current}" --pretty=format:"%s" | grep -oP '\(#\K\d+(?=\))' | sort -un)
 
-          for issue in $issues; do
+          # Resolve linked issues for each PR
+          issues=""
+          for pr in $prs; do
+            linked=$(gh pr view "$pr" --json closingIssuesReferences --jq '.closingIssuesReferences[].number')
+            issues="$issues $linked"
+          done
+
+          for issue in $(echo "$issues" | tr ' ' '\n' | sort -un); do
+            [ -z "$issue" ] && continue
             echo "Commenting on issue #$issue"
             gh issue comment "$issue" \
-              --body "Released in [\`${current}\`](https://github.com/${{ github.repository }}/releases/tag/${current})" \
-              || echo "Skipping #$issue (not a commentable issue)"
+              --body "Released in [\`${current}\`](https://github.com/${{ github.repository }}/releases/tag/${current})"
           done

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -75,5 +75,5 @@ jobs:
             [ -z "$issue" ] && continue
             echo "Commenting on issue #$issue"
             gh issue comment "$issue" \
-              --body "Released in [\`${current}\`](https://github.com/${{ github.repository }}/releases/tag/${current})"
+              --body "Released in \`${current}\`"
           done

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,8 +51,11 @@ jobs:
       - name: Get current and previous tags
         id: tags
         run: |
-          echo "current=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
-          echo "previous=$(git describe --tags --abbrev=0 HEAD^)" >> "$GITHUB_OUTPUT"
+          current="${GITHUB_REF_NAME}"
+          previous=$(git describe --tags --abbrev=0 HEAD^)
+          echo "current=$current" >> "$GITHUB_OUTPUT"
+          echo "previous=$previous" >> "$GITHUB_OUTPUT"
+          echo "Release range: $previous..$current"
 
       - name: Comment on released issues
         env:
@@ -67,6 +70,7 @@ jobs:
           # Resolve linked issues for each PR
           issues=""
           for pr in $prs; do
+            echo "Checking PR #$pr for linked issues"
             linked=$(gh pr view "$pr" --json closingIssuesReferences --jq '.closingIssuesReferences[].number')
             issues="$issues $linked"
           done


### PR DESCRIPTION
## Summary
This PR adds an automated workflow step that notifies users by commenting on issues when a new release is published. When a release is tagged, the workflow will automatically find all issues referenced in commit messages and post a comment indicating the release version