### PR TITLE
Add missing elements in globals.d.ts

### DIFF
--- a/src/globals.d.ts
+++ b/src/globals.d.ts
@@ -8,5 +8,6 @@ declare global {
     "calendar-multi": InstanceType<typeof CalendarMulti>;
     "calendar-select-month": InstanceType<typeof CalendarSelectMonth>;
     "calendar-select-year": InstanceType<typeof CalendarSelectYear>;
+    "calendar-heading": InstanceType<typeof CalendarHeading>;
   }
 }

--- a/src/globals.d.ts
+++ b/src/globals.d.ts
@@ -5,5 +5,8 @@ declare global {
     "calendar-month": InstanceType<typeof CalendarMonth>;
     "calendar-date": InstanceType<typeof CalendarDate>;
     "calendar-range": InstanceType<typeof CalendarRange>;
+    "calendar-multi": InstanceType<typeof CalendarMulti>;
+    "calendar-select-month": InstanceType<typeof CalendarSelectMonth>;
+    "calendar-select-year": InstanceType<typeof CalendarSelectYear>;
   }
 }


### PR DESCRIPTION
The calendar select elements added in #108 are missing from the global `HTMLElementTagNameMap` meaning e.g. VSCode thinks they don't exist. 

Add them in to `globals.d.ts` with the other elements.